### PR TITLE
Allow indirect proxy classes to implement their own functions

### DIFF
--- a/sshlib/src/main/java/com/trilead/ssh2/Connection.java
+++ b/sshlib/src/main/java/com/trilead/ssh2/Connection.java
@@ -9,8 +9,6 @@ import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
 import java.security.KeyPair;
 import java.security.SecureRandom;
-import java.security.Security;
-import java.util.Set;
 import java.util.Vector;
 
 import com.trilead.ssh2.auth.AuthenticationManager;
@@ -136,63 +134,6 @@ public class Connection
 	{
 		this.hostname = hostname;
 		this.port = port;
-	}
-
-	/**
-	 * After a successful connect, one has to authenticate oneself. This method
-	 * is based on DSA (it uses DSA to sign a challenge sent by the server).
-	 * <p>
-	 * If the authentication phase is complete, <code>true</code> will be
-	 * returned. If the server does not accept the request (or if further
-	 * authentication steps are needed), <code>false</code> is returned and
-	 * one can retry either by using this or any other authentication method
-	 * (use the <code>getRemainingAuthMethods</code> method to get a list of
-	 * the remaining possible methods).
-	 * 
-	 * @param user
-	 *            A <code>String</code> holding the username.
-	 * @param pem
-	 *            A <code>String</code> containing the DSA private key of the
-	 *            user in OpenSSH key format (PEM, you can't miss the
-	 *            "-----BEGIN DSA PRIVATE KEY-----" tag). The string may contain
-	 *            linefeeds.
-	 * @param password
-	 *            If the PEM string is 3DES encrypted ("DES-EDE3-CBC"), then you
-	 *            must specify the password. Otherwise, this argument will be
-	 *            ignored and can be set to <code>null</code>.
-	 * 
-	 * @return whether the connection is now authenticated.
-	 * @throws IOException
-	 * 
-	 * @deprecated You should use one of the
-	 *             {@link #authenticateWithPublicKey(String, File, String) authenticateWithPublicKey()}
-	 *             methods, this method is just a wrapper for it and will
-	 *             disappear in future builds.
-	 * 
-	 */
-	public synchronized boolean authenticateWithDSA(String user, String pem, String password) throws IOException
-	{
-		if (tm == null)
-			throw new IllegalStateException("Connection is not established!");
-
-		if (authenticated)
-			throw new IllegalStateException("Connection is already authenticated!");
-
-		if (am == null)
-			am = new AuthenticationManager(tm);
-
-		if (cm == null)
-			cm = new ChannelManager(tm);
-
-		if (user == null)
-			throw new IllegalArgumentException("user argument is null");
-
-		if (pem == null)
-			throw new IllegalArgumentException("pem argument is null");
-
-		authenticated = am.authenticatePublicKey(user, pem.toCharArray(), password, getOrCreateSecureRND());
-
-		return authenticated;
 	}
 
 	/**

--- a/sshlib/src/main/java/com/trilead/ssh2/Connection.java
+++ b/sshlib/src/main/java/com/trilead/ssh2/Connection.java
@@ -105,8 +105,6 @@ public class Connection
 
 	private TransportManager tm;
 
-	private boolean tcpNoDelay = false;
-
 	private ProxyData proxyData = null;
 
 	private Vector<ConnectionMonitor> connectionMonitors = new Vector<ConnectionMonitor>();
@@ -812,8 +810,6 @@ public class Connection
 						"The connect() operation on the socket timed out.").initCause(se);
 			}
 
-			tm.setTcpNoDelay(tcpNoDelay);
-
 			/* Wait until first KEX has finished */
 
 			ConnectionInfo ci = tm.getConnectionInfo(1);
@@ -1406,27 +1402,6 @@ public class Connection
 		algos = removeDuplicates(algos);
 		KexManager.checkServerHostkeyAlgorithmsList(algos);
 		cryptoWishList.serverHostKeyAlgorithms = algos;
-	}
-
-	/**
-	 * Enable/disable TCP_NODELAY (disable/enable Nagle's algorithm) on the
-	 * underlying socket.
-	 * <p>
-	 * Can be called at any time. If the connection has not yet been established
-	 * then the passed value will be stored and set after the socket has been
-	 * set up. The default value that will be used is <code>false</code>.
-	 * 
-	 * @param enable
-	 *            the argument passed to the <code>Socket.setTCPNoDelay()</code>
-	 *            method.
-	 * @throws IOException
-	 */
-	public synchronized void setTCPNoDelay(boolean enable) throws IOException
-	{
-		tcpNoDelay = enable;
-
-		if (tm != null)
-			tm.setTcpNoDelay(enable);
 	}
 
 	/**

--- a/sshlib/src/main/java/com/trilead/ssh2/HTTPProxyData.java
+++ b/sshlib/src/main/java/com/trilead/ssh2/HTTPProxyData.java
@@ -1,6 +1,16 @@
 
 package com.trilead.ssh2;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+import com.trilead.ssh2.crypto.Base64;
+import com.trilead.ssh2.transport.ClientServerHello;
+
 /**
  * A <code>HTTPProxyData</code> object is used to specify the needed connection data
  * to connect through a HTTP proxy. 
@@ -13,11 +23,11 @@ package com.trilead.ssh2;
 
 public class HTTPProxyData implements ProxyData
 {
-	public final String proxyHost;
-	public final int proxyPort;
-	public final String proxyUser;
-	public final String proxyPass;
-	public final String[] requestHeaderLines;
+	private final String proxyHost;
+	private final int proxyPort;
+	private final String proxyUser;
+	private final String proxyPass;
+	private final String[] requestHeaderLines;
 
 	/**
 	 * Same as calling {@link #HTTPProxyData(String, int, String, String) HTTPProxyData(proxyHost, proxyPort, <code>null</code>, <code>null</code>)}
@@ -79,5 +89,99 @@ public class HTTPProxyData implements ProxyData
 		this.proxyUser = proxyUser;
 		this.proxyPass = proxyPass;
 		this.requestHeaderLines = requestHeaderLines;
+	}
+
+	@Override
+	public Socket openConnection(String hostname, int port, int connectTimeout) throws IOException {
+		Socket sock = new Socket();
+
+		InetAddress addr = InetAddress.getByName(proxyHost);
+		sock.connect(new InetSocketAddress(addr, proxyPort), connectTimeout);
+		sock.setSoTimeout(0);
+
+			/* OK, now tell the proxy where we actually want to connect to */
+
+		StringBuffer sb = new StringBuffer();
+
+		sb.append("CONNECT ");
+		sb.append(hostname);
+		sb.append(':');
+		sb.append(port);
+		sb.append(" HTTP/1.0\r\n");
+
+		if ((proxyUser != null) && (proxyPass != null))
+		{
+			String credentials = proxyUser + ":" + proxyPass;
+			char[] encoded = Base64.encode(credentials.getBytes("ISO-8859-1"));
+			sb.append("Proxy-Authorization: Basic ");
+			sb.append(encoded);
+			sb.append("\r\n");
+		}
+
+		if (requestHeaderLines != null)
+		{
+			for (int i = 0; i < requestHeaderLines.length; i++)
+			{
+				if (requestHeaderLines[i] != null)
+				{
+					sb.append(requestHeaderLines[i]);
+					sb.append("\r\n");
+				}
+			}
+		}
+
+		sb.append("\r\n");
+
+		OutputStream out = sock.getOutputStream();
+
+		out.write(sb.toString().getBytes("ISO-8859-1"));
+		out.flush();
+
+			/* Now parse the HTTP response */
+
+		byte[] buffer = new byte[1024];
+		InputStream in = sock.getInputStream();
+
+		int len = ClientServerHello.readLineRN(in, buffer);
+
+		String httpReponse = new String(buffer, 0, len, "ISO-8859-1");
+
+		if (httpReponse.startsWith("HTTP/") == false)
+			throw new IOException("The proxy did not send back a valid HTTP response.");
+
+			/* "HTTP/1.X XYZ X" => 14 characters minimum */
+
+		if ((httpReponse.length() < 14) || (httpReponse.charAt(8) != ' ') || (httpReponse.charAt(12) != ' '))
+			throw new IOException("The proxy did not send back a valid HTTP response.");
+
+		int errorCode = 0;
+
+		try
+		{
+			errorCode = Integer.parseInt(httpReponse.substring(9, 12));
+		}
+		catch (NumberFormatException ignore)
+		{
+			throw new IOException("The proxy did not send back a valid HTTP response.");
+		}
+
+		if ((errorCode < 0) || (errorCode > 999))
+			throw new IOException("The proxy did not send back a valid HTTP response.");
+
+		if (errorCode != 200)
+		{
+			throw new HTTPProxyException(httpReponse.substring(13), errorCode);
+		}
+
+			/* OK, read until empty line */
+
+		while (true)
+		{
+			len = ClientServerHello.readLineRN(in, buffer);
+			if (len == 0)
+				break;
+		}
+
+		return sock;
 	}
 }

--- a/sshlib/src/main/java/com/trilead/ssh2/ProxyData.java
+++ b/sshlib/src/main/java/com/trilead/ssh2/ProxyData.java
@@ -1,8 +1,11 @@
 
 package com.trilead.ssh2;
 
+import java.io.IOException;
+import java.net.Socket;
+
 /**
- * An abstract marker interface implemented by all proxy data implementations.
+ * An abstract interface implemented by all proxy data implementations.
  * 
  * @see HTTPProxyData
  * 
@@ -10,6 +13,16 @@ package com.trilead.ssh2;
  * @version $Id: ProxyData.java,v 1.1 2007/10/15 12:49:56 cplattne Exp $
  */
 
-public abstract interface ProxyData
+public interface ProxyData
 {
+	/**
+	 * Connects the socket to the given destination using the proxy method that this instance
+	 * represents.
+	 * @param hostname hostname of end host (not proxy)
+	 * @param port port of end host (not proxy)
+	 * @param connectTimeout number of seconds before giving up on connecting to end host
+	 * @throws IOException if the connection could not be completed
+	 * @return connected socket instance
+	 */
+	Socket openConnection(String hostname, int port, int connectTimeout) throws IOException;
 }

--- a/sshlib/src/main/java/com/trilead/ssh2/transport/TransportManager.java
+++ b/sshlib/src/main/java/com/trilead/ssh2/transport/TransportManager.java
@@ -7,7 +7,6 @@ import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.security.SecureRandom;
 import java.util.Vector;
@@ -154,16 +153,6 @@ public class TransportManager
 	public int getPacketOverheadEstimate()
 	{
 		return tc.getPacketOverheadEstimate();
-	}
-
-	public void setTcpNoDelay(boolean state) throws IOException
-	{
-		sock.setTcpNoDelay(state);
-	}
-
-	public void setSoTimeout(int timeout) throws IOException
-	{
-		sock.setSoTimeout(timeout);
 	}
 
 	public ConnectionInfo getConnectionInfo(int kexNumber) throws IOException


### PR DESCRIPTION
Allow indirect proxy functions. We don't need sshlib to have knowledge of what the proxy is doing, it just needs to know how to get a (connected) socket from the proxy.
