### PR TITLE
Remove usage of BigInteger(byte[]) constructor

### DIFF
--- a/sshlib/src/main/java/com/trilead/ssh2/crypto/PEMDecoder.java
+++ b/sshlib/src/main/java/com/trilead/ssh2/crypto/PEMDecoder.java
@@ -477,7 +477,7 @@ public class PEMDecoder
 			if (params == null)
 				throw new IOException("invalid OID");
 
-			BigInteger s = new BigInteger(privateBytes);
+			BigInteger s = new BigInteger(1, privateBytes);
 			byte[] publicBytesSlice = new byte[publicBytes.length - 1];
 			System.arraycopy(publicBytes, 1, publicBytesSlice, 0, publicBytesSlice.length);
 			ECPoint w = ECDSASHA2Verify.decodeECPoint(publicBytesSlice, params.getCurve());

--- a/sshlib/src/main/java/com/trilead/ssh2/crypto/SimpleDERReader.java
+++ b/sshlib/src/main/java/com/trilead/ssh2/crypto/SimpleDERReader.java
@@ -126,7 +126,7 @@ public class SimpleDERReader
 
 		byte[] b = readBytes(len);
 		
-		BigInteger bi = new BigInteger(b);
+		BigInteger bi = new BigInteger(1, b);
 		
 		return bi;
 	}

--- a/sshlib/src/main/java/com/trilead/ssh2/crypto/dh/DhExchange.java
+++ b/sshlib/src/main/java/com/trilead/ssh2/crypto/dh/DhExchange.java
@@ -109,7 +109,7 @@ public class DhExchange extends GenericDhExchange {
 			KeyFactory kf = KeyFactory.getInstance("DH");
 			DHParameterSpec params = clientPublic.getParams();
 			this.serverPublic = (DHPublicKey) kf.generatePublic(new DHPublicKeySpec(
-					new BigInteger(f), params.getP(), params.getG()));
+					new BigInteger(1, f), params.getP(), params.getG()));
 
 			ka = KeyAgreement.getInstance("DH");
 			ka.init(clientPrivate);
@@ -122,7 +122,7 @@ public class DhExchange extends GenericDhExchange {
 			throw (IOException) new IOException("Invalid DH key").initCause(e);
 		}
 
-		sharedSecret = new BigInteger(ka.generateSecret());
+		sharedSecret = new BigInteger(1, ka.generateSecret());
 	}
 
 	@Override

--- a/sshlib/src/main/java/com/trilead/ssh2/packets/TypesReader.java
+++ b/sshlib/src/main/java/com/trilead/ssh2/packets/TypesReader.java
@@ -119,7 +119,7 @@ public class TypesReader
 		if (raw.length == 0)
 			b = BigInteger.ZERO;
 		else
-			b = new BigInteger(raw);
+			b = new BigInteger(1, raw);
 
 		return b;
 	}

--- a/sshlib/src/test/java/com/trilead/ssh2/crypto/SimpleDERReaderTest.java
+++ b/sshlib/src/test/java/com/trilead/ssh2/crypto/SimpleDERReaderTest.java
@@ -72,7 +72,7 @@ public class SimpleDERReaderTest {
                 (byte) 0x02, (byte) 0x04, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
         };
         SimpleDERReader reader = new SimpleDERReader(vector);
-        assertEquals(BigInteger.valueOf(0xFFFFFFFF), reader.readInt());
+        assertEquals("ffffffff", reader.readInt().toString(16));
     }
 
     @Test


### PR DESCRIPTION
This is usually wrong because we actually never want to handle negative
values. These should all be positive values, so we simply replace it
with "BigInteger(1, byte[])" instead.
