### PR TITLE
Update net.i2p.crypto.eddsa to 0.2.0

### DIFF
--- a/sshlib/build.gradle
+++ b/sshlib/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.jcraft:jzlib:1.1.3'
     compile 'org.connectbot:simplesocks:1.0.1'
+    compile 'net.i2p.crypto:eddsa:0.2.0'
     compile 'net.vrallev.ecc:ecc-25519-java:1.0.3'
     compile 'org.connectbot.jbcrypt:jbcrypt:1.0.0'
 

--- a/sshlib/src/main/java/com/trilead/ssh2/crypto/PEMDecoder.java
+++ b/sshlib/src/main/java/com/trilead/ssh2/crypto/PEMDecoder.java
@@ -585,8 +585,7 @@ public class PEMDecoder
 			if (Ed25519Verify.ED25519_ID.equals(keyType)) {
 				byte[] publicBytes = trEnc.readByteString();
 				byte[] privateBytes = trEnc.readByteString();
-				EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(
-						EdDSANamedCurveTable.CURVE_ED25519_SHA512);
+				EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(Ed25519Verify.ED25519_CURVE_NAME);
 				privKey = new EdDSAPrivateKey(new EdDSAPrivateKeySpec(
 						Arrays.copyOfRange(privateBytes, 0, 32), spec));
 				pubKey = new EdDSAPublicKey(new EdDSAPublicKeySpec(publicBytes, spec));

--- a/sshlib/src/main/java/com/trilead/ssh2/signature/Ed25519Verify.java
+++ b/sshlib/src/main/java/com/trilead/ssh2/signature/Ed25519Verify.java
@@ -43,6 +43,8 @@ public class Ed25519Verify {
 	/** Identifies this as an Ed25519 key in the protocol. */
 	public static final String ED25519_ID = "ssh-ed25519";
 
+	public static final String ED25519_CURVE_NAME = "Ed25519";
+
 	private static final int ED25519_PK_SIZE_BYTES = 32;
 	private static final int ED25519_SIG_SIZE_BYTES = 64;
 
@@ -74,8 +76,7 @@ public class Ed25519Verify {
 			throw new IOException("Ed25519 was not of correct length: " + keyBytes.length + " vs " + ED25519_PK_SIZE_BYTES);
 		}
 
-		return new EdDSAPublicKey(new EdDSAPublicKeySpec(keyBytes,
-				EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.CURVE_ED25519_SHA512)));
+		return new EdDSAPublicKey(new EdDSAPublicKeySpec(keyBytes, EdDSANamedCurveTable.getByName(ED25519_CURVE_NAME)));
 	}
 
 	public static byte[] generateSignature(byte[] msg, EdDSAPrivateKey privateKey) throws IOException {

--- a/sshlib/src/test/java/com/trilead/ssh2/signature/Ed25519VerifyTest.java
+++ b/sshlib/src/test/java/com/trilead/ssh2/signature/Ed25519VerifyTest.java
@@ -56,7 +56,7 @@ public class Ed25519VerifyTest {
 
 	@Before
 	public void setupSpec() {
-		this.spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.CURVE_ED25519_SHA512);
+		this.spec = EdDSANamedCurveTable.getByName(Ed25519Verify.ED25519_CURVE_NAME);
 	}
 
 	@Test


### PR DESCRIPTION
Update net.i2p.crypto.eddsa to 0.2.0 to allow loading keys with the new OIDs from draft-ietf-curdle-pkix.
This overrides dependency of net.vrallev.ecc.ecc-25519-java on eddsa-0.1.0.

[net.vrallev.ecc.ecc-25519-java](https://github.com/vRallev/ECC-25519) is probably not going to get updated anytime soon, since it has been deprecated.