### PR TITLE
Add RSA SHA2-256 and SHA2-512 support by accepting ext-info packets

### DIFF
--- a/sshlib/src/main/java/com/trilead/ssh2/ExtensionInfo.java
+++ b/sshlib/src/main/java/com/trilead/ssh2/ExtensionInfo.java
@@ -1,0 +1,47 @@
+package com.trilead.ssh2;
+
+import com.trilead.ssh2.packets.PacketExtInfo;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * SSH extensions reported by the server
+ *
+ * https://tools.ietf.org/html/draft-ietf-curdle-ssh-ext-info-15
+ */
+public class ExtensionInfo
+{
+	private final Set<String> signatureAlgorithmsAccepted;
+
+	/**
+	 * @return Signature algorithms that server will accept. If empty, this extension was absent.
+	 */
+	public Set<String> getSignatureAlgorithmsAccepted()
+	{
+		return signatureAlgorithmsAccepted;
+	}
+
+	public static ExtensionInfo fromPacketExtInfo(PacketExtInfo packetExtInfo)
+	{
+		String rawAlgs = packetExtInfo.getExtNameToValue().get("server-sig-algs");
+		if (rawAlgs == null)
+		{
+			return new ExtensionInfo(Collections.<String>emptySet());
+		}
+
+		Set<String> algsSet = new HashSet<>();
+		Collections.addAll(algsSet, rawAlgs.split(","));
+		return new ExtensionInfo(algsSet);
+	}
+
+	public static ExtensionInfo noExtInfoSeen()
+	{
+		return new ExtensionInfo(Collections.<String>emptySet());
+	}
+
+	private ExtensionInfo(Set<String> signatureAlgorithmsAccepted)
+	{
+		this.signatureAlgorithmsAccepted = Collections.unmodifiableSet(signatureAlgorithmsAccepted);
+	}
+}

--- a/sshlib/src/main/java/com/trilead/ssh2/packets/PacketExtInfo.java
+++ b/sshlib/src/main/java/com/trilead/ssh2/packets/PacketExtInfo.java
@@ -1,0 +1,76 @@
+package com.trilead.ssh2.packets;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+/**
+ * Packet format described here:
+ * https://tools.ietf.org/html/draft-ietf-curdle-ssh-ext-info-15#section-2.3
+ */
+public class PacketExtInfo
+{
+	private byte[] payload;
+
+	private final Map<String, String> extNameToValue;
+
+	public byte[] getPayload()
+	{
+		if (payload == null)
+		{
+			TypesWriter tw = new TypesWriter();
+			tw.writeByte(Packets.SSH_MSG_EXT_INFO);
+			tw.writeUINT32(extNameToValue.size());
+			for (Entry<String, String> nameAndValue : extNameToValue.entrySet())
+			{
+				tw.writeString(nameAndValue.getKey());
+				tw.writeString(nameAndValue.getValue());
+			}
+			payload = tw.getBytes();
+		}
+		return payload;
+	}
+
+	public Map<String, String> getExtNameToValue()
+	{
+		return extNameToValue;
+	}
+
+	public PacketExtInfo(byte payload[], int off, int len) throws IOException
+	{
+		this.payload = new byte[len];
+		System.arraycopy(payload, off, this.payload, 0, len);
+
+		TypesReader tr = new TypesReader(payload, off, len);
+		int packet_type = tr.readByte();
+		if (packet_type != Packets.SSH_MSG_EXT_INFO)
+		{
+			throw new IOException("This is not a SSH_MSG_EXT_INFO! ("
+					+ packet_type + ")");
+		}
+
+		// Type has dynamic number of fields
+		// First int tells us how many pairs to expect
+		int numExtensions = tr.readUINT32();
+		Map<String, String> extNameToValue_ = new HashMap<>(numExtensions);
+		for (int i = 0; i < numExtensions; i++)
+		{
+			String name = tr.readString();
+			String value = tr.readString();
+			extNameToValue_.put(name, value);
+		}
+		extNameToValue = Collections.unmodifiableMap(extNameToValue_);
+
+		if (tr.remain() != 0)
+		{
+			throw new IOException("Padding in SSH_MSG_EXT_INFO packet!");
+		}
+	}
+
+	public PacketExtInfo(Map<String, String> extNameToValue)
+	{
+		this.extNameToValue = Collections.unmodifiableMap(new HashMap<>(extNameToValue));
+	}
+}

--- a/sshlib/src/main/java/com/trilead/ssh2/packets/Packets.java
+++ b/sshlib/src/main/java/com/trilead/ssh2/packets/Packets.java
@@ -15,6 +15,7 @@ public class Packets
 	public static final int SSH_MSG_DEBUG = 4;
 	public static final int SSH_MSG_SERVICE_REQUEST = 5;
 	public static final int SSH_MSG_SERVICE_ACCEPT = 6;
+	public static final int SSH_MSG_EXT_INFO = 7;
 
 	public static final int SSH_MSG_KEXINIT = 20;
 	public static final int SSH_MSG_NEWKEYS = 21;
@@ -84,6 +85,7 @@ public class Packets
 		reverseNames[4] = "SSH_MSG_DEBUG";
 		reverseNames[5] = "SSH_MSG_SERVICE_REQUEST";
 		reverseNames[6] = "SSH_MSG_SERVICE_ACCEPT";
+		reverseNames[7] = "SSH_MSG_EXT_INFO";
 
 		reverseNames[20] = "SSH_MSG_KEXINIT";
 		reverseNames[21] = "SSH_MSG_NEWKEYS";

--- a/sshlib/src/main/java/com/trilead/ssh2/signature/RSASHA256Verify.java
+++ b/sshlib/src/main/java/com/trilead/ssh2/signature/RSASHA256Verify.java
@@ -1,0 +1,124 @@
+package com.trilead.ssh2.signature;
+
+import com.trilead.ssh2.log.Logger;
+import com.trilead.ssh2.packets.TypesReader;
+import com.trilead.ssh2.packets.TypesWriter;
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Signature;
+import java.security.SignatureException;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+
+public class RSASHA256Verify
+{
+	private static final Logger log = Logger.getLogger(RSASHA256Verify.class);
+
+	public static byte[] decodeRSASHA256Signature(byte[] sig) throws IOException
+	{
+		TypesReader tr = new TypesReader(sig);
+
+		String sig_format = tr.readString();
+
+		if (sig_format.equals("rsa-sha2-256") == false)
+			throw new IOException("Peer sent wrong signature format");
+
+		/* S is NOT an MPINT. "The value for 'rsa_signature_blob' is encoded as a string
+		 * containing s (which is an integer, without lengths or padding, unsigned and in
+		 * network byte order)." See also below.
+		 */
+
+		byte[] s = tr.readByteString();
+
+		if (s.length == 0)
+			throw new IOException("Error in RSA signature, S is empty.");
+
+		if (log.isEnabled())
+		{
+			log.log(80, "Decoding rsa-sha2-256 signature string (length: " + s.length + ")");
+		}
+
+		if (tr.remain() != 0)
+			throw new IOException("Padding in RSA signature!");
+
+		if (s[0] == 0 && s[1] == 0 && s[2] == 0) {
+			int i = 0;
+			int j = ((s[i++] << 24) & 0xff000000) | ((s[i++] << 16) & 0x00ff0000)
+					| ((s[i++] << 8) & 0x0000ff00) | ((s[i++]) & 0x000000ff);
+			i += j;
+			j = ((s[i++] << 24) & 0xff000000) | ((s[i++] << 16) & 0x00ff0000)
+					| ((s[i++] << 8) & 0x0000ff00) | ((s[i++]) & 0x000000ff);
+			byte[] tmp = new byte[j];
+			System.arraycopy(s, i, tmp, 0, j);
+			sig = tmp;
+		}
+
+		return s;
+	}
+
+	public static byte[] encodeRSASHA256Signature(byte[] s) throws IOException
+	{
+		TypesWriter tw = new TypesWriter();
+
+		tw.writeString("rsa-sha2-256");
+
+		/* S is NOT an MPINT. "The value for 'rsa_signature_blob' is encoded as a string
+		 * containing s (which is an integer, without lengths or padding, unsigned and in
+		 * network byte order)."
+		 */
+
+		/* Remove first zero sign byte, if present */
+
+		if ((s.length > 1) && (s[0] == 0x00))
+			tw.writeString(s, 1, s.length - 1);
+		else
+			tw.writeString(s, 0, s.length);
+
+		return tw.getBytes();
+	}
+
+	public static byte[] generateSignature(byte[] message, RSAPrivateKey pk) throws IOException
+	{
+		try {
+			Signature s = Signature.getInstance("SHA256withRSA");
+			s.initSign(pk);
+			s.update(message);
+			return s.sign();
+		} catch (NoSuchAlgorithmException e) {
+			IOException ex = new IOException();
+			ex.initCause(e);
+			throw ex;
+		} catch (InvalidKeyException e) {
+			IOException ex =  new IOException();
+			ex.initCause(e);
+			throw ex;
+		} catch (SignatureException e) {
+			IOException ex =  new IOException();
+			ex.initCause(e);
+			throw ex;
+		}
+	}
+
+	public static boolean verifySignature(byte[] message, byte[] ds, RSAPublicKey dpk) throws IOException
+	{
+		try {
+			Signature s = Signature.getInstance("SHA256withRSA");
+			s.initVerify(dpk);
+			s.update(message);
+			return s.verify(ds);
+		} catch (NoSuchAlgorithmException e) {
+			IOException ex = new IOException();
+			ex.initCause(e);
+			throw ex;
+		} catch (InvalidKeyException e) {
+			IOException ex = new IOException();
+			ex.initCause(e);
+			throw ex;
+		} catch (SignatureException e) {
+			IOException ex = new IOException();
+			ex.initCause(e);
+			throw ex;
+		}
+	}
+}

--- a/sshlib/src/main/java/com/trilead/ssh2/signature/RSASHA512Verify.java
+++ b/sshlib/src/main/java/com/trilead/ssh2/signature/RSASHA512Verify.java
@@ -1,0 +1,125 @@
+package com.trilead.ssh2.signature;
+
+import com.trilead.ssh2.log.Logger;
+import com.trilead.ssh2.packets.TypesReader;
+import com.trilead.ssh2.packets.TypesWriter;
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Signature;
+import java.security.SignatureException;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+
+public class RSASHA512Verify
+{
+	private static final Logger log = Logger.getLogger(RSASHA512Verify.class);
+
+	public static byte[] decodeRSASHA512Signature(byte[] sig) throws IOException
+	{
+		TypesReader tr = new TypesReader(sig);
+
+		String sig_format = tr.readString();
+
+		if (sig_format.equals("rsa-sha2-512") == false)
+			throw new IOException("Peer sent wrong signature format");
+
+		/* S is NOT an MPINT. "The value for 'rsa_signature_blob' is encoded as a string
+		 * containing s (which is an integer, without lengths or padding, unsigned and in
+		 * network byte order)." See also below.
+		 */
+
+		byte[] s = tr.readByteString();
+
+		if (s.length == 0)
+			throw new IOException("Error in RSA signature, S is empty.");
+
+		if (log.isEnabled())
+		{
+			log.log(80, "Decoding rsa-sha2-512 signature string (length: " + s.length + ")");
+		}
+
+		if (tr.remain() != 0)
+			throw new IOException("Padding in RSA signature!");
+
+		if (s[0] == 0 && s[1] == 0 && s[2] == 0) {
+			int i = 0;
+			int j = ((s[i++] << 24) & 0xff000000) | ((s[i++] << 16) & 0x00ff0000)
+					| ((s[i++] << 8) & 0x0000ff00) | ((s[i++]) & 0x000000ff);
+			i += j;
+			j = ((s[i++] << 24) & 0xff000000) | ((s[i++] << 16) & 0x00ff0000)
+					| ((s[i++] << 8) & 0x0000ff00) | ((s[i++]) & 0x000000ff);
+			byte[] tmp = new byte[j];
+			System.arraycopy(s, i, tmp, 0, j);
+			sig = tmp;
+		}
+
+		return s;
+	}
+
+	public static byte[] encodeRSASHA512Signature(byte[] s) throws IOException
+	{
+		TypesWriter tw = new TypesWriter();
+
+		tw.writeString("rsa-sha2-512");
+
+		/* S is NOT an MPINT. "The value for 'rsa_signature_blob' is encoded as a string
+		 * containing s (which is an integer, without lengths or padding, unsigned and in
+		 * network byte order)."
+		 */
+
+		/* Remove first zero sign byte, if present */
+
+		if ((s.length > 1) && (s[0] == 0x00))
+			tw.writeString(s, 1, s.length - 1);
+		else
+			tw.writeString(s, 0, s.length);
+
+		return tw.getBytes();
+	}
+
+	public static byte[] generateSignature(byte[] message, RSAPrivateKey pk) throws IOException
+	{
+		try {
+			// Android's Signature is guaranteed to support this instance
+			Signature s = Signature.getInstance("SHA512withRSA");
+			s.initSign(pk);
+			s.update(message);
+			return s.sign();
+		} catch (NoSuchAlgorithmException e) {
+			IOException ex = new IOException();
+			ex.initCause(e);
+			throw ex;
+		} catch (InvalidKeyException e) {
+			IOException ex =  new IOException();
+			ex.initCause(e);
+			throw ex;
+		} catch (SignatureException e) {
+			IOException ex =  new IOException();
+			ex.initCause(e);
+			throw ex;
+		}
+	}
+
+	public static boolean verifySignature(byte[] message, byte[] ds, RSAPublicKey dpk) throws IOException
+	{
+		try {
+			Signature s = Signature.getInstance("SHA512withRSA");
+			s.initVerify(dpk);
+			s.update(message);
+			return s.verify(ds);
+		} catch (NoSuchAlgorithmException e) {
+			IOException ex = new IOException();
+			ex.initCause(e);
+			throw ex;
+		} catch (InvalidKeyException e) {
+			IOException ex = new IOException();
+			ex.initCause(e);
+			throw ex;
+		} catch (SignatureException e) {
+			IOException ex = new IOException();
+			ex.initCause(e);
+			throw ex;
+		}
+	}
+}

--- a/sshlib/src/main/java/com/trilead/ssh2/transport/KexManager.java
+++ b/sshlib/src/main/java/com/trilead/ssh2/transport/KexManager.java
@@ -1,6 +1,8 @@
 
 package com.trilead.ssh2.transport;
 
+import com.trilead.ssh2.signature.RSASHA256Verify;
+import com.trilead.ssh2.signature.RSASHA512Verify;
 import java.io.IOException;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
@@ -77,6 +79,8 @@ public class KexManager
 		}
 		HOSTKEY_ALGS.add("ssh-rsa");
 		HOSTKEY_ALGS.add("ssh-dss");
+		HOSTKEY_ALGS.add("rsa-sha2-256");
+		HOSTKEY_ALGS.add("rsa-sha2-512");
 	}
 
 	private static final Set<String> KEX_ALGS = new LinkedHashSet<String>();
@@ -91,6 +95,9 @@ public class KexManager
 		KEX_ALGS.add("diffie-hellman-group-exchange-sha1");
 		KEX_ALGS.add("diffie-hellman-group14-sha1");
 		KEX_ALGS.add("diffie-hellman-group1-sha1");
+
+		// Indicate client support for ext-info
+		KEX_ALGS.add("ext-info-c");
 	}
 
 	KexState kxs;
@@ -448,6 +455,26 @@ public class KexManager
 			log.log(50, "Verifying ssh-rsa signature");
 
 			return RSASHA1Verify.verifySignature(kxs.H, rs, rpk);
+		}
+
+		if (kxs.np.server_host_key_algo.equals("rsa-sha2-256"))
+		{
+			byte[] rs = RSASHA256Verify.decodeRSASHA256Signature(sig);
+			RSAPublicKey rpk = RSASHA1Verify.decodeSSHRSAPublicKey(hostkey);
+
+			log.log(50, "Verifying rsa-sha2-256 signature");
+
+			return RSASHA256Verify.verifySignature(kxs.H, rs, rpk);
+		}
+
+		if (kxs.np.server_host_key_algo.equals("rsa-sha2-512"))
+		{
+			byte[] rs = RSASHA512Verify.decodeRSASHA512Signature(sig);
+			RSAPublicKey rpk = RSASHA1Verify.decodeSSHRSAPublicKey(hostkey);
+
+			log.log(50, "Verifying rsa-sha2-512 signature");
+
+			return RSASHA512Verify.verifySignature(kxs.H, rs, rpk);
 		}
 
 		if (kxs.np.server_host_key_algo.equals("ssh-dss"))


### PR DESCRIPTION
Adds SHA2 support for client authentication, ssh-agent authentication,
and server host keys.

Accepts ext-info packets from the server. Only "server-sig-algs" is used
atm.