### PR TITLE
Add integration tests for compression

### DIFF
--- a/sshlib/src/main/java/com/trilead/ssh2/ConnectionInfo.java
+++ b/sshlib/src/main/java/com/trilead/ssh2/ConnectionInfo.java
@@ -50,4 +50,16 @@ public class ConnectionInfo
 	 * Number of kex exchanges performed on this connection so far.
 	 */
 	public int keyExchangeCounter = 0;
+
+	/**
+	 * The currently used compression algorithm for packets from the client to
+	 * the server.
+	 */
+	public String clientToServerCompressionAlgorithm;
+
+	/**
+	 * The currently used compression algorithm for packets from the server to
+	 * the client.
+	 */
+	public String serverToClientCompressionAlgorithm;
 }

--- a/sshlib/src/main/java/com/trilead/ssh2/transport/KexManager.java
+++ b/sshlib/src/main/java/com/trilead/ssh2/transport/KexManager.java
@@ -615,6 +615,8 @@ public class KexManager
 			sci.serverToClientMACAlgorithm = kxs.np.mac_algo_server_to_client;
 			sci.serverHostKeyAlgorithm = kxs.np.server_host_key_algo;
 			sci.serverHostKey = kxs.hostkey;
+			sci.clientToServerCompressionAlgorithm = kxs.np.comp_algo_client_to_server;
+			sci.serverToClientCompressionAlgorithm = kxs.np.comp_algo_server_to_client;
 
 			synchronized (accessLock)
 			{


### PR DESCRIPTION
The compression used was not available before, but this adds it to
the ConnectionInfo class.