### PR TITLE
Fixes RSA keys with OpenSSH 7.8

### DIFF
--- a/sshlib/src/main/java/com/trilead/ssh2/auth/AuthenticationManager.java
+++ b/sshlib/src/main/java/com/trilead/ssh2/auth/AuthenticationManager.java
@@ -236,8 +236,8 @@ public class AuthenticationManager implements MessageHandler
 			else if (publicKey instanceof RSAPublicKey)
 			{
 				byte[] pk_enc = RSASHA1Verify.encodeSSHRSAPublicKey((RSAPublicKey) publicKey);
+				String pk_algorithm;
 
-				byte[] msg = this.generatePublicKeyUserAuthenticationRequest(user, "ssh-rsa", pk_enc);
 
 				// Servers support different hash algorithms for RSA keys
 				// https://tools.ietf.org/html/draft-ietf-curdle-rsa-sha2-12
@@ -246,6 +246,8 @@ public class AuthenticationManager implements MessageHandler
 
 				if (algsAccepted.contains("rsa-sha2-512"))
 				{
+					pk_algorithm = "rsa-sha2-512";
+					byte[] msg = this.generatePublicKeyUserAuthenticationRequest(user, pk_algorithm, pk_enc);
 					if (signatureProxy != null)
 					{
 						rsa_sig_enc = signatureProxy.sign(msg, SignatureProxy.SHA512);
@@ -259,6 +261,9 @@ public class AuthenticationManager implements MessageHandler
 				}
 				else if (algsAccepted.contains("rsa-sha2-256"))
 				{
+					pk_algorithm = "rsa-sha2-256";
+					byte[] msg = this.generatePublicKeyUserAuthenticationRequest(user, pk_algorithm, pk_enc);
+
 					if (signatureProxy != null)
 					{
 						rsa_sig_enc = signatureProxy.sign(msg, SignatureProxy.SHA256);
@@ -272,6 +277,8 @@ public class AuthenticationManager implements MessageHandler
 				}
 				else
 				{
+					pk_algorithm = "ssh-rsa";
+					byte[] msg = this.generatePublicKeyUserAuthenticationRequest(user, pk_algorithm, pk_enc);
 					if (signatureProxy != null)
 					{
 						rsa_sig_enc = signatureProxy.sign(msg, SignatureProxy.SHA1);
@@ -286,7 +293,7 @@ public class AuthenticationManager implements MessageHandler
 				}
 
 				PacketUserauthRequestPublicKey ua = new PacketUserauthRequestPublicKey("ssh-connection", user,
-						"ssh-rsa", pk_enc, rsa_sig_enc);
+						pk_algorithm, pk_enc, rsa_sig_enc);
 
 				tm.sendMessage(ua.getPayload());
 			}

--- a/sshlib/src/main/java/com/trilead/ssh2/transport/KexManager.java
+++ b/sshlib/src/main/java/com/trilead/ssh2/transport/KexManager.java
@@ -79,10 +79,10 @@ public class KexManager
 			HOSTKEY_ALGS.add("ecdsa-sha2-nistp384");
 			HOSTKEY_ALGS.add("ecdsa-sha2-nistp521");
 		}
+		HOSTKEY_ALGS.add("rsa-sha2-512");
+		HOSTKEY_ALGS.add("rsa-sha2-256");
 		HOSTKEY_ALGS.add("ssh-rsa");
 		HOSTKEY_ALGS.add("ssh-dss");
-		HOSTKEY_ALGS.add("rsa-sha2-256");
-		HOSTKEY_ALGS.add("rsa-sha2-512");
 	}
 
 	private static final Set<String> KEX_ALGS = new LinkedHashSet<>();
@@ -426,6 +426,7 @@ public class KexManager
 			return Ed25519Verify.verifySignature(kxs.H, eds, edpk);
 
 		}
+
 		if (kxs.np.server_host_key_algo.startsWith("ecdsa-sha2-"))
 		{
 			byte[] rs = ECDSASHA2Verify.decodeSSHECDSASignature(sig);
@@ -436,14 +437,14 @@ public class KexManager
 			return ECDSASHA2Verify.verifySignature(kxs.H, rs, epk);
 		}
 
-		if (kxs.np.server_host_key_algo.equals("ssh-rsa"))
+		if (kxs.np.server_host_key_algo.equals("rsa-sha2-512"))
 		{
-			byte[] rs = RSASHA1Verify.decodeSSHRSASignature(sig);
+			byte[] rs = RSASHA512Verify.decodeRSASHA512Signature(sig);
 			RSAPublicKey rpk = RSASHA1Verify.decodeSSHRSAPublicKey(hostkey);
 
-			log.log(50, "Verifying ssh-rsa signature");
+			log.log(50, "Verifying rsa-sha2-512 signature");
 
-			return RSASHA1Verify.verifySignature(kxs.H, rs, rpk);
+			return RSASHA512Verify.verifySignature(kxs.H, rs, rpk);
 		}
 
 		if (kxs.np.server_host_key_algo.equals("rsa-sha2-256"))
@@ -456,14 +457,14 @@ public class KexManager
 			return RSASHA256Verify.verifySignature(kxs.H, rs, rpk);
 		}
 
-		if (kxs.np.server_host_key_algo.equals("rsa-sha2-512"))
+		if (kxs.np.server_host_key_algo.equals("ssh-rsa"))
 		{
-			byte[] rs = RSASHA512Verify.decodeRSASHA512Signature(sig);
+			byte[] rs = RSASHA1Verify.decodeSSHRSASignature(sig);
 			RSAPublicKey rpk = RSASHA1Verify.decodeSSHRSAPublicKey(hostkey);
 
-			log.log(50, "Verifying rsa-sha2-512 signature");
+			log.log(50, "Verifying ssh-rsa signature");
 
-			return RSASHA512Verify.verifySignature(kxs.H, rs, rpk);
+			return RSASHA1Verify.verifySignature(kxs.H, rs, rpk);
 		}
 
 		if (kxs.np.server_host_key_algo.equals("ssh-dss"))

--- a/sshlib/src/test/resources/openssh-server/Dockerfile
+++ b/sshlib/src/test/resources/openssh-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:edge
 ENV USERNAME testuser
 ENV PASSWORD testtest123
 ENV OPTIONS ""


### PR DESCRIPTION
Merging this fixes the apparent root cause of connectbot/connectbot#656 and the integration tests to make sure of it.

Previous integration test was using OpenSSH 7.7 which didn't have this incompatibility.