### PR TITLE
Travis-CI: Use OpenJDK instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: java
 jdk:
-  - oraclejdk9
-  - oraclejdk8
+  - openjdk9
+  - openjdk11
 addons:
   apt:
     packages:
       - docker-ce
-      - oracle-java8-installer
 services:
   - docker
 cache:

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,5 +25,5 @@ description=SSH library used in the ConnectBot app
 bintrayUser=dummyUser
 bintrayApiKey=dummyApiKey
 
-officialJdk=oraclejdk9
+officialJdk=openjdk9
 gitHubUrl=https\://github.com/connectbot/sshlib


### PR DESCRIPTION
The new license for Oracle JDK downloads seem something worthy
of avoidance.