### PR TITLE
Ed25519 fix

### DIFF
--- a/src/main/java/com/trilead/ssh2/crypto/keys/EdDSAPrivateKey.java
+++ b/src/main/java/com/trilead/ssh2/crypto/keys/EdDSAPrivateKey.java
@@ -1,16 +1,30 @@
 package com.trilead.ssh2.crypto.keys;
 
+import com.trilead.ssh2.packets.TypesReader;
+import com.trilead.ssh2.packets.TypesWriter;
+
+import java.io.IOException;
 import java.security.PrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Arrays;
 
 import javax.security.auth.DestroyFailedException;
 
 public class EdDSAPrivateKey implements PrivateKey {
+	private static final byte[] ED25519_OID = new byte[] {43, 101, 112};
+	private static final int KEY_BYTES_LENGTH = 32;
+	private static final int ENCODED_SIZE = 48;
+
 	private final byte[] keyBytes;
 	private boolean destroyed;
 
-	public EdDSAPrivateKey(byte[] keyBytes) {
-		this.keyBytes = keyBytes;
+	public EdDSAPrivateKey(byte[] seed) {
+		this.keyBytes = seed;
+	}
+
+	public EdDSAPrivateKey(PKCS8EncodedKeySpec keySpec) throws InvalidKeySpecException {
+		this.keyBytes = decode(keySpec);
 	}
 
 	@Override
@@ -20,12 +34,70 @@ public class EdDSAPrivateKey implements PrivateKey {
 
 	@Override
 	public String getFormat() {
-		return "RAW";
+		return "PKCS#8";
+	}
+
+	public byte[] getSeed() {
+		return keyBytes;
 	}
 
 	@Override
 	public byte[] getEncoded() {
-		return keyBytes;
+		// From RFC 8410 section 7 "Private Key Format"
+		TypesWriter tw = new TypesWriter();
+		// ASN.1 Sequence
+		tw.writeByte(0x30);
+		tw.writeByte(11 + ED25519_OID.length + keyBytes.length); // Length
+		// Key version type
+		tw.writeByte(0x02); // ASN.1 Integer
+		tw.writeByte(1); // Length
+		tw.writeByte(0); // v1 == RFC 5208 format
+		// Algorithm OID - ASN.1 Sequence
+		tw.writeByte(0x30);
+		tw.writeByte(ED25519_OID.length + 2); // OID
+		tw.writeByte(0x06); // ASN.1 OID type
+		tw.writeByte(ED25519_OID.length);
+		tw.writeBytes(ED25519_OID);
+		// Private key sequence
+		tw.writeByte(0x04); // ASN.1 Octet string
+		tw.writeByte(2 + keyBytes.length);
+		tw.writeByte(0x04); // ASN.1 Octet string
+		tw.writeByte(keyBytes.length);
+		tw.writeBytes(keyBytes);
+
+		return tw.getBytes();
+	}
+
+	private static byte[] decode(PKCS8EncodedKeySpec keySpec) throws InvalidKeySpecException {
+		byte[] encoded = keySpec.getEncoded();
+		if (encoded.length != ENCODED_SIZE) {
+			throw new InvalidKeySpecException("Key spec is of invalid size");
+		}
+		try {
+			TypesReader tr = new TypesReader(keySpec.getEncoded());
+			if (tr.readByte() != 0x30 || // ASN.1 sequence
+				tr.readByte() != ENCODED_SIZE - 2 || // Expected size
+				tr.readByte() != 0x02 || // ASN.1 Integer
+				tr.readByte() != 1 || // length
+				tr.readByte() != 0 || // v1
+				tr.readByte() != 0x30 || // ASN.1 Sequence
+				tr.readByte() != ED25519_OID.length + 2 || // OID length
+				tr.readByte() != 0x06 || // ASN.1 OID
+				tr.readByte() != ED25519_OID.length) {
+				throw new InvalidKeySpecException("Key was not encoded correctly");
+			}
+			byte[] oid = tr.readBytes(ED25519_OID.length);
+			if (!Arrays.equals(ED25519_OID, oid) ||
+				tr.readByte() != 0x04 || // ASN.1 octet string
+				tr.readByte() != KEY_BYTES_LENGTH + 2 || // length
+				tr.readByte() != 0x04 || // ASN.1 octet string
+				tr.readByte() != KEY_BYTES_LENGTH) {
+				throw new InvalidKeySpecException("Key was not encoded correctly");
+			}
+			return tr.readBytes(KEY_BYTES_LENGTH);
+		} catch (IOException e) {
+			throw new InvalidKeySpecException("Key was not encoded correctly", e);
+		}
 	}
 
 	@Override

--- a/src/main/java/com/trilead/ssh2/crypto/keys/EdDSAPublicKey.java
+++ b/src/main/java/com/trilead/ssh2/crypto/keys/EdDSAPublicKey.java
@@ -1,12 +1,27 @@
 package com.trilead.ssh2.crypto.keys;
 
+import com.trilead.ssh2.packets.TypesReader;
+import com.trilead.ssh2.packets.TypesWriter;
+
+import java.io.IOException;
 import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Arrays;
 
 public class EdDSAPublicKey implements PublicKey {
+	private static final byte[] ED25519_OID = new byte[]{43, 101, 112};
+	private static final int KEY_BYTES_LENGTH = 32;
+	private static final int ENCODED_SIZE = 44;
+
 	private final byte[] keyBytes;
 
 	public EdDSAPublicKey(byte[] keyBytes) {
 		this.keyBytes = keyBytes;
+	}
+
+	public EdDSAPublicKey(X509EncodedKeySpec keySpec) throws InvalidKeySpecException {
+		keyBytes = decode(keySpec.getEncoded());
 	}
 
 	@Override
@@ -16,11 +31,57 @@ public class EdDSAPublicKey implements PublicKey {
 
 	@Override
 	public String getFormat() {
-		return "RAW";
+		return "X.509";
 	}
 
 	@Override
 	public byte[] getEncoded() {
+		TypesWriter tw = new TypesWriter();
+		tw.writeByte(0x30); // ASN.1 sequence
+		tw.writeByte(7 + ED25519_OID.length + keyBytes.length);
+		// Algorithm identifier
+		tw.writeByte(0x30); // ASN.1 sequence
+		tw.writeByte(2 + ED25519_OID.length);
+		tw.writeByte(0x06); // ASN.1 OID
+		tw.writeByte(ED25519_OID.length);
+		tw.writeBytes(ED25519_OID);
+		// Public key
+		tw.writeByte(0x03); // ASN.1 bit string
+		tw.writeByte(keyBytes.length + 1);
+		tw.writeByte(0);
+		tw.writeBytes(keyBytes);
+		return tw.getBytes();
+	}
+
+	private static byte[] decode(byte[] input) throws InvalidKeySpecException {
+		if (input.length != ENCODED_SIZE) {
+			throw new InvalidKeySpecException("Key is not of correct size");
+		}
+
+		try {
+			TypesReader tr = new TypesReader(input);
+			if (tr.readByte() != 0x30 ||
+				tr.readByte() != 7 + ED25519_OID.length + KEY_BYTES_LENGTH ||
+				tr.readByte() != 0x30 ||
+				tr.readByte() != 2 + ED25519_OID.length ||
+				tr.readByte() != 0x06 ||
+				tr.readByte() != ED25519_OID.length) {
+				throw new InvalidKeySpecException("Key was not encoded correctly");
+			}
+			byte[] oid = tr.readBytes(ED25519_OID.length);
+			if (!Arrays.equals(oid, ED25519_OID) ||
+				tr.readByte() != 0x03 ||
+				tr.readByte() != KEY_BYTES_LENGTH + 1 ||
+				tr.readByte() != 0) {
+				throw new InvalidKeySpecException("Key was not encoded correctly");
+			}
+			return tr.readBytes(KEY_BYTES_LENGTH);
+		} catch (IOException e) {
+			throw new InvalidKeySpecException("Key was not encoded correctly");
+		}
+	}
+
+	public byte[] getAbyte() {
 		return keyBytes;
 	}
 }

--- a/src/main/java/com/trilead/ssh2/signature/Ed25519Verify.java
+++ b/src/main/java/com/trilead/ssh2/signature/Ed25519Verify.java
@@ -57,7 +57,7 @@ public class Ed25519Verify {
 		TypesWriter tw = new TypesWriter();
 
 		tw.writeString(ED25519_ID);
-		byte[] encoded = key.getEncoded();
+		byte[] encoded = key.getAbyte();
 		tw.writeString(encoded, 0, encoded.length);
 
 		return tw.getBytes();
@@ -86,7 +86,7 @@ public class Ed25519Verify {
 
 	public static byte[] generateSignature(byte[] msg, EdDSAPrivateKey privateKey) throws IOException {
 		try {
-			return new Ed25519Sign(privateKey.getEncoded()).sign(msg);
+			return new Ed25519Sign(privateKey.getSeed()).sign(msg);
 		} catch (GeneralSecurityException e) {
 			throw new IOException(e);
 		}
@@ -94,7 +94,7 @@ public class Ed25519Verify {
 
 	public static boolean verifySignature(byte[] msg, byte[] sig, EdDSAPublicKey publicKey) throws IOException {
 		try {
-			new com.google.crypto.tink.subtle.Ed25519Verify(publicKey.getEncoded()).verify(sig, msg);
+			new com.google.crypto.tink.subtle.Ed25519Verify(publicKey.getAbyte()).verify(sig, msg);
 			return true;
 		} catch (GeneralSecurityException e) {
 			return false;

--- a/src/test/java/com/trilead/ssh2/DropbearCompatibilityTest.java
+++ b/src/test/java/com/trilead/ssh2/DropbearCompatibilityTest.java
@@ -155,7 +155,7 @@ public class DropbearCompatibilityTest {
 
 	@Test
 	public void connectToRsaHost() throws Exception {
-		assertCanConnectToServerThatHasKeyType("/etc/dropbear/dropbear_rsa_host_key", "ssh-rsa");
+		assertCanConnectToServerThatHasKeyType("/etc/dropbear/dropbear_rsa_host_key", "rsa-sha2-256");
 	}
 
 	@Test
@@ -223,21 +223,6 @@ public class DropbearCompatibilityTest {
 	@Test
 	public void canConnectWithCipherAes256Ctr() throws Exception {
 		assertCanConnectToServerWithCipher("aes256-ctr");
-	}
-
-	@Test
-	public void canConnectWithCipherAes128Cbc() throws Exception {
-		assertCanConnectToServerWithCipher("aes128-cbc");
-	}
-
-	@Test
-	public void canConnectWithCipherAes256Cbc() throws Exception {
-		assertCanConnectToServerWithCipher("aes256-cbc");
-	}
-
-	@Test
-	public void canConnectWithCipher3desCbc() throws Exception {
-		assertCanConnectToServerWithCipher("3des-cbc");
 	}
 
 	private void setMac(Connection c, String mac) {


### PR DESCRIPTION
I originally didn't provide correct encoding for Ed25519 keys which led to some issues trying to re-hydrate them. This fixes that problem.