### PR TITLE
Support ssh-rsa host keys with sha2 signature

### DIFF
--- a/src/main/java/com/trilead/ssh2/KnownHosts.java
+++ b/src/main/java/com/trilead/ssh2/KnownHosts.java
@@ -101,7 +101,7 @@ public class KnownHosts
 		if (hostnames == null)
 			throw new IllegalArgumentException("hostnames may not be null");
 
-		if ("ssh-rsa".equals(serverHostKeyAlgorithm))
+		if ("ssh-rsa".equals(serverHostKeyAlgorithm) || serverHostKeyAlgorithm.startsWith("rsa-sha2-"))
 		{
 			RSAPublicKey rpk = RSASHA1Verify.decodeSSHRSAPublicKey(serverHostKey);
 
@@ -597,7 +597,7 @@ public class KnownHosts
 	{
 		PublicKey remoteKey = null;
 
-		if ("ssh-rsa".equals(serverHostKeyAlgorithm))
+		if ("ssh-rsa".equals(serverHostKeyAlgorithm) || serverHostKeyAlgorithm.startsWith("rsa-sha2-"))
 		{
 			remoteKey = RSASHA1Verify.decodeSSHRSAPublicKey(serverHostKey);
 		}


### PR DESCRIPTION
This adds support for rsa-sha2-256 and rsa-sha2-512 host keys. The host key
itself is still an rsa key but with sha2 signatures, so there is no new code
needed to decode the host key. The sha2 signatures are already supported, too.

This will fix https://github.com/connectbot/connectbot/issues/698 (after updating the library in connectbot).