### PR TITLE
LocalPortForwarder: Add getters for local port

### DIFF
--- a/src/main/java/com/trilead/ssh2/LocalPortForwarder.java
+++ b/src/main/java/com/trilead/ssh2/LocalPortForwarder.java
@@ -51,6 +51,10 @@ public class LocalPortForwarder
 		lat.start();
 	}
 
+	public int getLocalPort() {
+		return lat.getLocalPort();
+	}
+
 	/**
 	 * Stop TCP/IP forwarding of newly arriving connections.
 	 *

--- a/src/main/java/com/trilead/ssh2/channel/LocalAcceptThread.java
+++ b/src/main/java/com/trilead/ssh2/channel/LocalAcceptThread.java
@@ -41,6 +41,10 @@ public class LocalAcceptThread extends Thread implements IChannelWorkerThread
 		ss.bind(localAddress);
 	}
 
+	public int getLocalPort() {
+		return ss.getLocalPort();
+	}
+
 	public void run()
 	{
 		try


### PR DESCRIPTION
If 0 is specified as local port during construction, the port number is automatically allocated. This port number can be retrieved using these getters.

Fixes: #97 