### PR TITLE
Exclude transitive dependencies from Tink

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,9 @@ apply(from = "$rootDir/config/quality.gradle.kts")
 dependencies {
     implementation("com.jcraft:jzlib:1.1.3")
     implementation("org.connectbot:simplesocks:1.0.1")
-    implementation("com.google.crypto.tink:tink:1.12.0")
+    implementation("com.google.crypto.tink:tink:1.12.0") {
+        isTransitive = false
+    }
     implementation("org.connectbot:jbcrypt:1.0.2")
 
     testImplementation("junit:junit:4.13.2")


### PR DESCRIPTION
It was pulling in errorprone and findbugs and etc