### PR TITLE
EdDSA: update handling to allow other providers

### DIFF
--- a/src/main/java/com/trilead/ssh2/auth/AuthenticationManager.java
+++ b/src/main/java/com/trilead/ssh2/auth/AuthenticationManager.java
@@ -2,7 +2,6 @@
 package com.trilead.ssh2.auth;
 
 import com.trilead.ssh2.crypto.keys.Ed25519PrivateKey;
-import com.trilead.ssh2.crypto.keys.Ed25519PublicKey;
 import com.trilead.ssh2.signature.RSASHA256Verify;
 import com.trilead.ssh2.signature.RSASHA512Verify;
 import java.io.IOException;
@@ -316,7 +315,7 @@ public class AuthenticationManager implements MessageHandler
 
 				tm.sendMessage(ua.getPayload());
 			}
-			else if (publicKey instanceof Ed25519PublicKey)
+			else if ("EdDSA".equals(publicKey.getAlgorithm()))
 			{
 				final String algo = Ed25519Verify.ED25519_ID;
 

--- a/src/main/java/com/trilead/ssh2/crypto/keys/Ed25519KeyFactory.java
+++ b/src/main/java/com/trilead/ssh2/crypto/keys/Ed25519KeyFactory.java
@@ -33,7 +33,28 @@ public class Ed25519KeyFactory extends KeyFactorySpi {
 	}
 
 	@Override
-	protected Key engineTranslateKey(Key key) throws InvalidKeyException {
-		throw new InvalidKeyException("No other EdDSA key providers known");
+	public Key engineTranslateKey(Key key) throws InvalidKeyException {
+		if (key instanceof Ed25519PublicKey || key instanceof Ed25519PrivateKey) {
+			return key;
+		}
+		if (key instanceof PublicKey && key.getFormat().equals("X.509")) {
+			byte[] encoded = key.getEncoded();
+			try {
+				return new Ed25519PublicKey(new X509EncodedKeySpec(encoded));
+			} catch (InvalidKeySpecException e) {
+				throw new InvalidKeyException(e);
+			}
+		}
+
+		if (key instanceof PrivateKey && key.getFormat().equals("PKCS#8")) {
+			byte[] encoded = key.getEncoded();
+			try {
+				return new Ed25519PrivateKey(new PKCS8EncodedKeySpec(encoded));
+			} catch (InvalidKeySpecException e) {
+				throw new InvalidKeyException(e);
+			}
+		}
+
+		throw new InvalidKeyException("Could not convert EdDSA key from key class " + key.getClass());
 	}
 }

--- a/src/main/java/com/trilead/ssh2/crypto/keys/Ed25519Provider.java
+++ b/src/main/java/com/trilead/ssh2/crypto/keys/Ed25519Provider.java
@@ -6,12 +6,13 @@ import java.security.Provider;
 import java.security.Security;
 
 public class Ed25519Provider extends Provider {
+	public static final String NAME = "ConnectBot Ed25519 Provider";
 	public static final String KEY_ALGORITHM = "Ed25519";
 	private static final Object sInitLock = new Object();
 	private static boolean sInitialized = false;
 
 	public Ed25519Provider() {
-		super("ConnectBot Ed25519 Provider", 1.0, "Not for use elsewhere");
+		super(NAME, 1.0, "Not for use elsewhere");
 		AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
 			setup();
 			return null;

--- a/src/test/java/com/trilead/ssh2/crypto/keys/Ed25519KeyFactoryTest.java
+++ b/src/test/java/com/trilead/ssh2/crypto/keys/Ed25519KeyFactoryTest.java
@@ -3,11 +3,17 @@ package com.trilead.ssh2.crypto.keys;
 import org.junit.Test;
 
 import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertArrayEquals;
 
 public class Ed25519KeyFactoryTest {
 	private static final byte[] PRIVATE = toByteArray("302e020100300506032b657004220420f72a0a036e3479e15edb74da5f2a5418e66db450ad50687cad90247eeab6440c");
@@ -40,5 +46,39 @@ public class Ed25519KeyFactoryTest {
 		KeyFactory kf = KeyFactory.getInstance("Ed25519", p);
 		Ed25519PublicKey pub = (Ed25519PublicKey) kf.generatePublic(new X509EncodedKeySpec(PUBLIC));
 		assertThat(pub.getAbyte(), is(KAT_ED25519_PUB));
+	}
+
+	@Test
+	public void translatesNativeJDKKeys() throws Exception {
+		KeyPairGenerator kpg;
+		try {
+			kpg = KeyPairGenerator.getInstance("EdDSA");
+		} catch (NoSuchAlgorithmException e) {
+			// Skip test if EdDSA is not supported by the JDK
+			System.err.println("Skipping translatesNativeJDKKeys test: EdDSA not supported by this JDK");
+			return;
+		}
+
+		KeyPair keyPair = kpg.generateKeyPair();
+		PublicKey nativePubKey = keyPair.getPublic();
+		PrivateKey nativePrivKey = keyPair.getPrivate();
+
+		Ed25519KeyFactory keyFactorySpi = new Ed25519KeyFactory();
+
+		// Translate Public Key
+		PublicKey translatedPubKey = (PublicKey) keyFactorySpi.engineTranslateKey(nativePubKey);
+		assertThat(translatedPubKey.getAlgorithm(), is("EdDSA"));
+		assertThat(translatedPubKey.getFormat(), is("X.509"));
+		assertArrayEquals(nativePubKey.getEncoded(), translatedPubKey.getEncoded());
+		assertThat(((Ed25519PublicKey) translatedPubKey).getAbyte(), is(((Ed25519PublicKey) keyFactorySpi
+				.engineGeneratePublic(new X509EncodedKeySpec(nativePubKey.getEncoded()))).getAbyte()));
+
+		// Translate Private Key
+		PrivateKey translatedPrivKey = (PrivateKey) keyFactorySpi.engineTranslateKey(nativePrivKey);
+		assertThat(translatedPrivKey.getAlgorithm(), is("EdDSA"));
+		assertThat(translatedPrivKey.getFormat(), is("PKCS#8"));
+		assertArrayEquals(nativePrivKey.getEncoded(), translatedPrivKey.getEncoded());
+		assertThat(((Ed25519PrivateKey) translatedPrivKey).getSeed(), is(((Ed25519PrivateKey) keyFactorySpi
+				.engineGeneratePrivate(new PKCS8EncodedKeySpec(nativePrivKey.getEncoded()))).getSeed()));
 	}
 }

--- a/src/test/java/com/trilead/ssh2/signature/Ed25519VerifyTest.java
+++ b/src/test/java/com/trilead/ssh2/signature/Ed25519VerifyTest.java
@@ -8,6 +8,10 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
@@ -189,5 +193,31 @@ public class Ed25519VerifyTest {
 		byte[] pubKeyEncoded = pubKey.getEncoded();
 		Ed25519PublicKey pubKey2 = new Ed25519PublicKey(new X509EncodedKeySpec(pubKeyEncoded));
 		assertThat(pubKey.getAbyte(), is(pubKey2.getAbyte()));
+	}
+
+	@Test
+	public void nativeJDKConversion() throws Exception {
+		java.security.KeyPairGenerator kpg;
+		try {
+			kpg = KeyPairGenerator.getInstance("EdDSA");
+		} catch (NoSuchAlgorithmException e) {
+			// Skip test if EdDSA is not supported by the JDK
+			System.err.println("Skipping nativeJDKConversion test: EdDSA not supported by this JDK");
+			return;
+		}
+
+		KeyPair keyPair = kpg.generateKeyPair();
+
+		// Convert and check Public Key
+		PublicKey nativePubKey = keyPair.getPublic();
+		X509EncodedKeySpec pubKeySpec = new X509EncodedKeySpec(nativePubKey.getEncoded());
+		Ed25519PublicKey convertedPubKey = new Ed25519PublicKey(pubKeySpec);
+		assertArrayEquals(nativePubKey.getEncoded(), convertedPubKey.getEncoded());
+
+		// Convert and check Private Key
+		PrivateKey nativePrivKey = keyPair.getPrivate();
+		PKCS8EncodedKeySpec privKeySpec = new PKCS8EncodedKeySpec(nativePrivKey.getEncoded());
+		Ed25519PrivateKey convertedPrivKey = new Ed25519PrivateKey(privKeySpec);
+		assertArrayEquals(nativePrivKey.getEncoded(), convertedPrivKey.getEncoded());
 	}
 }


### PR DESCRIPTION
Allow keys from other providers by implementing engineTranslateKey. This will hopefully allow us to handle the new Android implementation without inspecting it deeply.

Part of the fix for https://github.com/connectbot/connectbot/issues/1483