### PR TITLE
asyncssh: run test as non-root user in Docker

### DIFF
--- a/src/test/resources/asyncssh-server/Dockerfile
+++ b/src/test/resources/asyncssh-server/Dockerfile
@@ -2,19 +2,26 @@ FROM python:3.13-slim-bookworm AS builder
 RUN apt-get update && \
     apt-get install -y gcc openssh-server && \
     apt-get clean
+WORKDIR /app
 COPY requirements.txt /app/requirements.txt
-WORKDIR app
 RUN pip install --user -r requirements.txt
-RUN mkdir -p /etc/ssh && ssh-keygen -A
+RUN mkdir -p /app/etc/ssh && ssh-keygen -A -f /app
 COPY . /app
 
 FROM python:3.13-slim-bookworm AS app
-COPY --from=builder /etc/ssh /etc/ssh
-COPY --from=builder /root/.local /root/.local
+COPY --from=builder /app/etc/ssh /app/etc/ssh
+COPY --from=builder /root/.local /app/.local
 COPY --from=builder /app/server.py /app/server.py
-WORKDIR app
+
+USER root
+RUN groupadd -g 1234 testserver && \
+    useradd -m -u 1234 -g testserver -d /app testserver && \
+    chown -R testserver:testserver /app
+WORKDIR /app
+USER 1234:1234
+
 EXPOSE 8022
 ENV PYTHONUNBUFFERED=0
-ENTRYPOINT ["python", "-u", "server.py"]
+CMD ["python", "-u", "server.py"]
 COPY *.pub /app/
 RUN cat /app/*.pub > /app/authorized_keys && rm -f /app/*.pub

--- a/src/test/resources/asyncssh-server/server.py
+++ b/src/test/resources/asyncssh-server/server.py
@@ -49,8 +49,8 @@ async def start_server():
     asyncssh.set_debug_level(2)
     await asyncssh.create_server(MySSHServer, '', 8022,
                                  server_host_keys=[
-                                     '/etc/ssh/ssh_host_ecdsa_key',
-                                     '/etc/ssh/ssh_host_rsa_key',
+                                     '/app/etc/ssh/ssh_host_ecdsa_key',
+                                     '/app/etc/ssh/ssh_host_rsa_key',
                                  ],
                                  process_factory=handle_client)
 


### PR DESCRIPTION
This shouldn't be used outside of the tests, but just in case someone copies what we're doing here…