### PR TITLE
Force Ed25519Provider to be prioritized above system implementations

### DIFF
--- a/src/main/java/com/trilead/ssh2/crypto/keys/Ed25519Provider.java
+++ b/src/main/java/com/trilead/ssh2/crypto/keys/Ed25519Provider.java
@@ -35,7 +35,7 @@ public class Ed25519Provider extends Provider {
 	public static void insertIfNeeded() {
 		synchronized (sInitLock) {
 			if (!sInitialized) {
-				Security.addProvider(new Ed25519Provider());
+				Security.insertProviderAt(new Ed25519Provider(), 1);
 				sInitialized = true;
 			}
 		}


### PR DESCRIPTION
https://github.com/connectbot/connectbot/issues/1508: A newly introduced system ED25519 implementation which is added to the provider list before this app-provided implementation is, with the result that logic which special cases key types based on class heirarchy breaks.

This commit fixes this by simply jumping the app-provided implementation to the front of the provider list.

Is this an ideal fix? Probably not. It may be better to adapt the class heirarchy logic to recognize the new system class.  That may be device specific though, as the implementation is provided by google's Conscrypt library.

I've rolled this into connectbot and tested it on my own device, and it does work.