### PR TITLE
Handle Conscrypt EdDSA keys in authentication flow

### DIFF
--- a/src/main/java/com/trilead/ssh2/auth/AuthenticationManager.java
+++ b/src/main/java/com/trilead/ssh2/auth/AuthenticationManager.java
@@ -1,6 +1,7 @@
 
 package com.trilead.ssh2.auth;
 
+import com.trilead.ssh2.crypto.PublicKeyUtils;
 import com.trilead.ssh2.crypto.keys.Ed25519PrivateKey;
 import com.trilead.ssh2.signature.RSASHA256Verify;
 import com.trilead.ssh2.signature.RSASHA512Verify;
@@ -316,7 +317,7 @@ public class AuthenticationManager implements MessageHandler
 
 				tm.sendMessage(ua.getPayload());
 			}
-			else if ("EdDSA".equals(publicKey.getAlgorithm()))
+			else if (PublicKeyUtils.isEd25519Key(publicKey))
 			{
 				final String algo = Ed25519Verify.ED25519_ID;
 

--- a/src/main/java/com/trilead/ssh2/crypto/PublicKeyUtils.java
+++ b/src/main/java/com/trilead/ssh2/crypto/PublicKeyUtils.java
@@ -102,7 +102,7 @@ public class PublicKeyUtils {
 	 * (e.g., JDK, Conscrypt/Google Play Services) which may use different algorithm names or
 	 * class names for Ed25519 keys.
 	 */
-	static boolean isEd25519Key(PublicKey publicKey) {
+	public static boolean isEd25519Key(PublicKey publicKey) {
 		String algorithm = publicKey.getAlgorithm();
 		if ("EdDSA".equals(algorithm) || "Ed25519".equals(algorithm) || "1.3.101.112".equals(algorithm)) {
 			return true;


### PR DESCRIPTION
AuthenticationManager used a strict "EdDSA" algorithm name check which failed for Conscrypt keys (e.g., from Google Play Services) that may use OID or other algorithm identifiers. Reuse PublicKeyUtils.isEd25519Key() for consistent detection across all code paths.