### PR TITLE
Guard for older versions of Android

### DIFF
--- a/src/main/java/com/trilead/ssh2/crypto/dh/X25519ProviderFactory.java
+++ b/src/main/java/com/trilead/ssh2/crypto/dh/X25519ProviderFactory.java
@@ -46,6 +46,7 @@ public class X25519ProviderFactory {
 	private static boolean isPlatformNativeAvailable() {
 		try {
 			KeyPairGenerator.getInstance("X25519");
+			Class.forName("java.security.spec.XECPrivateKeySpec");
 			return true;
 		} catch (Exception e) {
 			return false;


### PR DESCRIPTION
X25519 was not a good test to determine if Android has support for X25519 that indicates platform support. We also need to check whether XECPrivateKey is needed.