### PR TITLE
Skip returned null KnownHosts entries

### DIFF
--- a/src/main/java/com/trilead/ssh2/channel/ChannelManager.java
+++ b/src/main/java/com/trilead/ssh2/channel/ChannelManager.java
@@ -1901,6 +1901,8 @@ public class ChannelManager implements MessageHandler
 
 		if (knownAlgos != null) {
 			for (String knownAlgo : knownAlgos) {
+				if (knownAlgo == null)
+					continue;
 				if (!advertisedAlgoSet.contains(knownAlgo)) {
 					extVerifier.removeServerHostKey(hostname, port, knownAlgo, null);
 					if (log.isEnabled())


### PR DESCRIPTION
The called Extended Host Verifier can return a list entry with null in it which can cause issues when asking the implementation to remove it from its database. Skip those entries instead of sending them.