### PR TITLE
Add a way to get the connection addresses

### DIFF
--- a/src/main/java/com/trilead/ssh2/Connection.java
+++ b/src/main/java/com/trilead/ssh2/Connection.java
@@ -1076,6 +1076,34 @@ public class Connection implements AutoCloseable
 	}
 
 	/**
+	 * Returns the local address to which the socket is bound.
+	 *
+	 * @return the local address to which the socket is bound.
+	 * @throws IOException
+	 *             in case of any problem.
+	 */
+	public synchronized InetSocketAddress getLocalSocketAddress() throws IOException
+	{
+		if (tm == null)
+			throw new IllegalStateException("You need to establish a connection first.");
+		return tm.getLocalSocketAddress();
+	}
+
+	/**
+	 * Returns the address of the endpoint this socket is connected to.
+	 *
+	 * @return the address of the endpoint this socket is connected to.
+	 * @throws IOException
+	 *             in case of any problem.
+	 */
+	public synchronized InetSocketAddress getRemoteSocketAddress() throws IOException
+	{
+		if (tm == null)
+			throw new IllegalStateException("You need to establish a connection first.");
+		return tm.getRemoteSocketAddress();
+	}
+
+	/**
 	 * After a successful connect, one has to authenticate oneself. This method
 	 * can be used to tell which authentication methods are supported by the
 	 * server at a certain stage of the authentication process (for the given

--- a/src/main/java/com/trilead/ssh2/ConnectionInfo.java
+++ b/src/main/java/com/trilead/ssh2/ConnectionInfo.java
@@ -1,6 +1,8 @@
 
 package com.trilead.ssh2;
 
+import java.net.InetSocketAddress;
+
 /**
  * In most cases you probably do not need the information contained in here.
  *
@@ -9,6 +11,16 @@ package com.trilead.ssh2;
  */
 public class ConnectionInfo
 {
+	/**
+	 * The address of the local socket.
+	 */
+	public InetSocketAddress localSocketAddress;
+
+	/**
+	 * The address of the remote socket.
+	 */
+	public InetSocketAddress remoteSocketAddress;
+
 	/**
 	 * The used key exchange (KEX) algorithm in the latest key exchange.
 	 */

--- a/src/main/java/com/trilead/ssh2/transport/KexManager.java
+++ b/src/main/java/com/trilead/ssh2/transport/KexManager.java
@@ -729,6 +729,16 @@ public class KexManager
 
 			ConnectionInfo sci = new ConnectionInfo();
 
+			try
+			{
+				sci.localSocketAddress = tm.getLocalSocketAddress();
+				sci.remoteSocketAddress = tm.getRemoteSocketAddress();
+			}
+			catch (IOException e)
+			{
+				/* Ignore, if the connection is closed then it doesn't matter much anyway */
+			}
+
 			kexCount++;
 
 			sci.keyExchangeAlgorithm = kxs.np.kex_algo;

--- a/src/main/java/com/trilead/ssh2/transport/TransportManager.java
+++ b/src/main/java/com/trilead/ssh2/transport/TransportManager.java
@@ -4,6 +4,7 @@ package com.trilead.ssh2.transport;
 import com.trilead.ssh2.ExtensionInfo;
 import com.trilead.ssh2.packets.PacketExtInfo;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.security.SecureRandom;
 import java.util.Vector;
@@ -182,6 +183,26 @@ public class TransportManager implements ITransportConnection
 	public int getPort()
 	{
 		return port;
+	}
+
+	public InetSocketAddress getLocalSocketAddress() throws IOException
+	{
+		synchronized (connectionSemaphore)
+		{
+			if (sock == null)
+				throw new IOException("The connection is closed.");
+			return (InetSocketAddress) sock.getLocalSocketAddress();
+		}
+	}
+
+	public InetSocketAddress getRemoteSocketAddress() throws IOException
+	{
+		synchronized (connectionSemaphore)
+		{
+			if (sock == null)
+				throw new IOException("The connection is closed.");
+			return (InetSocketAddress) sock.getRemoteSocketAddress();
+		}
 	}
 
 	public ServerHostKeyVerifier getServerHostKeyVerifier()

--- a/src/test/java/com/trilead/ssh2/ConnectionTest.java
+++ b/src/test/java/com/trilead/ssh2/ConnectionTest.java
@@ -149,13 +149,36 @@ public void testSetSecureRandomWithNull() {
 @Test
 public void testGetConnectionInfoThrowsWhenNotConnected() {
 	try {
-	connection.getConnectionInfo();
-	fail("Should throw IllegalStateException when not connected");
+		connection.getConnectionInfo();
+		fail("Should throw IllegalStateException when not connected");
 	} catch (IllegalStateException e) {
-	assertTrue(e.getMessage().contains("establish a connection first"), "Exception message should indicate connection required");
+		assertTrue(e.getMessage().contains("establish a connection first"), "Exception message should indicate connection required");
 	} catch (Exception e) {
-	fail("Should throw IllegalStateException, got: " +
-		e.getClass().getSimpleName());
+		fail("Should throw IllegalStateException, got: " + e.getClass().getSimpleName());
+	}
+}
+
+@Test
+public void testGetLocalSocketAddressThrowsWhenNotConnected() {
+	try {
+		connection.getLocalSocketAddress();
+		fail("Should throw IllegalStateException when not connected");
+	} catch (IllegalStateException e) {
+		assertTrue(e.getMessage().contains("establish a connection first"), "Exception message should indicate connection required");
+	} catch (Exception e) {
+		fail("Should throw IllegalStateException, got: " + e.getClass().getSimpleName());
+	}
+}
+
+@Test
+public void testGetRemoteSocketAddressThrowsWhenNotConnected() {
+	try {
+		connection.getRemoteSocketAddress();
+		fail("Should throw IllegalStateException when not connected");
+	} catch (IllegalStateException e) {
+		assertTrue(e.getMessage().contains("establish a connection first"), "Exception message should indicate connection required");
+	} catch (Exception e) {
+		fail("Should throw IllegalStateException, got: " + e.getClass().getSimpleName());
 	}
 }
 

--- a/src/test/java/com/trilead/ssh2/OpenSSHCompatibilityTest.java
+++ b/src/test/java/com/trilead/ssh2/OpenSSHCompatibilityTest.java
@@ -15,10 +15,12 @@ import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 
 import com.trilead.ssh2.crypto.Base64;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
@@ -97,6 +99,28 @@ public class OpenSSHCompatibilityTest {
 				try (Session session = connection.openSession()) {
 					session.ping();
 				}
+			}
+		}
+	}
+
+	@Test
+	public void testSocketAddress() throws IOException {
+		try (GenericContainer<?> server = getBaseContainer()) {
+			server.start();
+			try (Connection c = withServer(server)) {
+				c.connect(verifier);
+
+				InetSocketAddress local = c.getLocalSocketAddress();
+				InetSocketAddress remote = c.getRemoteSocketAddress();
+
+				assertThat(local, notNullValue());
+				assertThat(remote, notNullValue());
+				assertThat(remote.getHostString(), is(server.getHost()));
+				assertThat(remote.getPort(), is(server.getMappedPort(22)));
+
+				ConnectionInfo info = c.getConnectionInfo();
+				assertThat(info.localSocketAddress.toString(), is(local.toString()));
+				assertThat(info.remoteSocketAddress.toString(), is(remote.toString()));
 			}
 		}
 	}


### PR DESCRIPTION
The local and remote socket address is used for tracking connectivity in ConnectBot.