### PR TITLE
feat: expose SSH_MSG_USERAUTH_BANNER messages via Connection.getBanners()

### DIFF
--- a/src/main/java/com/trilead/ssh2/Connection.java
+++ b/src/main/java/com/trilead/ssh2/Connection.java
@@ -9,6 +9,8 @@ import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
 import java.security.KeyPair;
 import java.security.SecureRandom;
+import java.util.Collections;
+import java.util.List;
 import java.util.Vector;
 
 import com.trilead.ssh2.auth.AuthenticationManager;
@@ -493,6 +495,37 @@ public class Connection implements AutoCloseable
 		{
 			throw new IllegalArgumentException("user argument is null");
 		}
+	}
+
+	/**
+	 * Returns the {@code SSH_MSG_USERAUTH_BANNER} messages sent by the server.
+	 * <p>
+	 * The server may send banners at any time before authentication completes
+	 * (typically used to display login notices or, in the case of Tailscale SSH,
+	 * a web URL the user must visit to finish authenticating). Banners received
+	 * during a blocking {@code authenticateWith*} call are accumulated and can
+	 * be read either while the call is in progress (from another thread) or
+	 * after it returns.
+	 *
+	 * @return list of banner strings in the order received, never {@code null};
+	 *         empty if no banners have been received or authentication has not
+	 *         been attempted yet.
+	 * @see com.trilead.ssh2.auth.AuthenticationManager#getBanners()
+	 */
+	public List<String> getBanners()
+	{
+		// Intentionally NOT synchronized on this Connection. The other authentication
+		// entry points (authenticateWithNone, authenticateWithPassword, ...) hold the
+		// Connection monitor for the entire duration of the blocking auth call. A
+		// caller that wants to display banners live — e.g. Tailscale SSH's web-login
+		// URL, which arrives in a banner BEFORE USERAUTH_SUCCESS — must be able to
+		// read them from another thread while that call is still blocked.
+		AuthenticationManager local = am;
+		if (local == null)
+		{
+			return Collections.emptyList();
+		}
+		return local.getBanners();
 	}
 
 	/**

--- a/src/main/java/com/trilead/ssh2/auth/AuthenticationManager.java
+++ b/src/main/java/com/trilead/ssh2/auth/AuthenticationManager.java
@@ -54,7 +54,7 @@ public class AuthenticationManager implements MessageHandler
 	List<byte[]> packets = new ArrayList<>();
 	boolean connectionClosed = false;
 
-	String banner;
+	List<String> banners = new ArrayList<>();
 
 	String[] remainingMethods = new String[0];
 	boolean isPartialSuccess = false;
@@ -114,7 +114,33 @@ public class AuthenticationManager implements MessageHandler
 
 			PacketUserauthBanner sb = new PacketUserauthBanner(msg, 0, msg.length);
 
-			banner = sb.getBanner();
+			synchronized (banners)
+			{
+				banners.add(sb.getBanner());
+			}
+		}
+	}
+
+	/**
+	 * Returns the {@code SSH_MSG_USERAUTH_BANNER} messages sent by the server.
+	 * The server may send banners at any point before authentication completes
+	 * (typically used to display login notices or, in the case of Tailscale SSH,
+	 * a web URL the user must visit to finish authenticating).
+	 * <p>
+	 * Returns a defensive snapshot, so the caller is free to iterate without
+	 * holding any locks. Synchronizes only on the {@code banners} list itself,
+	 * NOT on the {@code AuthenticationManager} or {@code Connection} monitor,
+	 * so it remains callable from another thread while a blocking
+	 * {@code authenticateWith*} call is in progress.
+	 *
+	 * @return list of banner strings in the order received, never {@code null};
+	 *         empty if the server has not sent any.
+	 */
+	public List<String> getBanners()
+	{
+		synchronized (banners)
+		{
+			return new ArrayList<>(banners);
 		}
 	}
 

--- a/src/test/java/com/trilead/ssh2/ConnectionTest.java
+++ b/src/test/java/com/trilead/ssh2/ConnectionTest.java
@@ -310,4 +310,14 @@ public void testSetAlgorithmMethods() {
 	String[] testKexAlgos = {"diffie-hellman-group1-sha1"}; // Basic DH group
 	connection.setKeyExchangeAlgorithms(testKexAlgos);
 }
+
+@Test
+public void testGetBannersReturnsEmptyBeforeAuthentication() {
+	// Before any authentication attempt, AuthenticationManager has not been created
+	// yet, so the accessor must return an empty list rather than throwing or
+	// returning null.
+	assertNotNull(connection.getBanners(), "getBanners() must never return null");
+	assertTrue(connection.getBanners().isEmpty(),
+			"getBanners() must be empty before authentication");
+}
 }


### PR DESCRIPTION
## Summary

Today `SSH_MSG_USERAUTH_BANNER` messages are read by
`AuthenticationManager` but stored in a package-private field
(`String banner`) that no caller outside the library can reach. That
makes it impossible to surface banners to users — most painfully when
the server is a [Tailscale-managed sshd](https://tailscale.com/kb/1193/tailscale-ssh/)
that delivers a web-login URL in a banner and then waits for the user
to finish the web login before sending `USERAUTH_SUCCESS`. The
`authenticateWithNone()` call blocks the whole time and the user has
no way to see the URL they need to visit.

This change mirrors the upstream trilead-ssh2 patch in
[jenkinsci/trilead-ssh2#206](https://github.com/jenkinsci/trilead-ssh2/pull/206):

- **`AuthenticationManager`**: store banners in a `List<String>` so
  multiple banners aren't clobbered, and expose a public
  `getBanners()` that returns a defensive snapshot.
- **`Connection`**: add a public `getBanners()` that delegates to the
  auth manager, returning an empty list when authentication hasn't
  been attempted yet.

## Threading

Neither accessor synchronizes on the `Connection` or
`AuthenticationManager` monitor. The blocking `authenticateWith*`
entry points already hold the `Connection` monitor for the full
duration of the auth call, so a caller that wants to surface banners
live — Tailscale's URL arrives in a banner *before* `USERAUTH_SUCCESS`
— must be able to read them from another thread while the auth call
is still in flight. Synchronization is scoped to the `banners` list
itself: the auth thread holds the list monitor while appending; the
accessor holds it briefly while copying out a snapshot.

## Why now

ConnectBot has [issue #1150](https://github.com/connectbot/connectbot/issues/1150)
open for the Tailscale-banner case. In
[connectbot#2211](https://github.com/connectbot/connectbot/pull/2211)
the workaround uses reflection on the package-private `am`/`banner`
fields. Once this API ships in a sshlib release, that reflection block
can be replaced with `connection.getBanners()`.

I've tested this exact change end-to-end against a Tailscale-managed
sshd by publishing this branch as `2.2.47-SNAPSHOT` to mavenLocal,
pointing a connectbot debug build at it, and swapping the reflection
block for a polling loop over `connection.banners`: the
`https://login.tailscale.com/a/...` URL now appears in the terminal
during the auth wait and is also picked up by URL Scan.

## Compatibility

- No source- or binary-breaking changes: the package-private
  `String banner` field is replaced with a package-private
  `List<String> banners`. That field was never part of the public API.
- New public methods only, no removals.

## Test plan

- [x] Added `ConnectionTest#testGetBannersReturnsEmptyBeforeAuthentication`
      verifying `getBanners()` returns a non-null, empty list when
      `am` hasn't been instantiated yet.
- [x] `./gradlew compileJava` passes (pre-existing `AccessController`
      deprecation warning only, unrelated).
- [x] `./gradlew test --tests "com.trilead.ssh2.ConnectionTest"` passes.
- [x] `./gradlew spotlessCheck` passes.
- [x] End-to-end Tailscale test from a connectbot debug build pinned
      to a local SNAPSHOT of this branch (see Why now).