### PR TITLE
feat(banner): add API for userauth banner fetching

### DIFF
--- a/src/main/java/com/trilead/ssh2/Connection.java
+++ b/src/main/java/com/trilead/ssh2/Connection.java
@@ -9,6 +9,8 @@ import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
 import java.security.KeyPair;
 import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Vector;
 
 import com.trilead.ssh2.auth.AuthenticationManager;
@@ -107,6 +109,8 @@ public class Connection implements AutoCloseable
 	private ProxyData proxyData = null;
 
 	private Vector<ConnectionMonitor> connectionMonitors = new Vector<ConnectionMonitor>();
+	private final List<UserAuthBannerCallback> bannerCallbacks =
+			new ArrayList<UserAuthBannerCallback>();
 
 	/**
 	 * Prepares a fresh <code>Connection</code> object which can then be used
@@ -481,7 +485,7 @@ public class Connection implements AutoCloseable
 
 		if (am == null)
 		{
-			am = new AuthenticationManager(tm);
+			am = new AuthenticationManager(tm, bannerCallbacks);
 		}
 
 		if (cm == null)
@@ -519,6 +523,49 @@ public class Connection implements AutoCloseable
 
 		if (tm != null)
 			tm.setConnectionMonitors(connectionMonitors);
+	}
+
+	/**
+	 * Add a {@link UserAuthBannerCallback} to this connection. Can be invoked
+	 * before or after <code>connect()</code>, but callers interested in banners
+	 * that arrive before authentication starts should register the callback
+	 * before invoking <code>connect()</code>.
+	 *
+	 * @param cb
+	 *            callback that will receive server authentication banners.
+	 */
+	public synchronized void addUserAuthBanner(UserAuthBannerCallback cb)
+	{
+		if (cb == null)
+			throw new IllegalArgumentException("cb argument is null");
+
+		synchronized (bannerCallbacks)
+		{
+			bannerCallbacks.add(cb);
+		}
+
+		if (tm != null)
+			tm.setUserAuthBannerCallbacks(bannerCallbacks);
+	}
+
+	/**
+	 * Remove a {@link UserAuthBannerCallback} from this connection.
+	 *
+	 * @param cb
+	 *            callback to remove.
+	 */
+	public synchronized void removeUserAuthBanner(UserAuthBannerCallback cb)
+	{
+		if (cb == null)
+			throw new IllegalArgumentException("cb argument is null");
+
+		synchronized (bannerCallbacks)
+		{
+			bannerCallbacks.remove(cb);
+		}
+
+		if (tm != null)
+			tm.setUserAuthBannerCallbacks(bannerCallbacks);
 	}
 
 	/**
@@ -745,6 +792,7 @@ public class Connection implements AutoCloseable
 		tm = new TransportManager(hostname, port);
 
 		tm.setConnectionMonitors(connectionMonitors);
+		tm.setUserAuthBannerCallbacks(bannerCallbacks);
 
 		// Don't offer compression if not requested
 		if (!compression) {

--- a/src/main/java/com/trilead/ssh2/UserAuthBannerCallback.java
+++ b/src/main/java/com/trilead/ssh2/UserAuthBannerCallback.java
@@ -1,0 +1,24 @@
+package com.trilead.ssh2;
+
+/**
+ * A <code>UserAuthBannerCallback</code> is used to receive authentication
+ * banners sent by the server.
+ *
+ * @see Connection#addUserAuthBanner(UserAuthBannerCallback)
+ */
+public interface UserAuthBannerCallback
+{
+	/**
+	 * Called when the server sends an SSH_MSG_USERAUTH_BANNER packet.
+	 * <p>
+	 * Note: clients SHOULD use control character filtering as discussed in
+	 * RFC4251 to avoid attacks by including terminal control characters in the
+	 * fields to be displayed.
+	 *
+	 * @param banner
+	 *            the banner message sent by the server.
+	 * @param language
+	 *            the language tag sent by the server. This is often empty.
+	 */
+	void receiveBanner(String banner, String language);
+}

--- a/src/main/java/com/trilead/ssh2/auth/AuthenticationManager.java
+++ b/src/main/java/com/trilead/ssh2/auth/AuthenticationManager.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.trilead.ssh2.InteractiveCallback;
+import com.trilead.ssh2.UserAuthBannerCallback;
 import com.trilead.ssh2.crypto.PEMDecoder;
 import com.trilead.ssh2.packets.PacketServiceAccept;
 import com.trilead.ssh2.packets.PacketServiceRequest;
@@ -50,6 +51,7 @@ import com.trilead.ssh2.transport.TransportManager;
 public class AuthenticationManager implements MessageHandler
 {
 	TransportManager tm;
+	List<UserAuthBannerCallback> bannerCallbacks;
 
 	List<byte[]> packets = new ArrayList<>();
 	boolean connectionClosed = false;
@@ -64,7 +66,13 @@ public class AuthenticationManager implements MessageHandler
 
 	public AuthenticationManager(TransportManager tm)
 	{
+		this(tm, new ArrayList<UserAuthBannerCallback>());
+	}
+
+	public AuthenticationManager(TransportManager tm, List<UserAuthBannerCallback> bannerCallbacks)
+	{
 		this.tm = tm;
+		this.bannerCallbacks = bannerCallbacks;
 	}
 
 	boolean methodPossible(String methName)
@@ -115,6 +123,29 @@ public class AuthenticationManager implements MessageHandler
 			PacketUserauthBanner sb = new PacketUserauthBanner(msg, 0, msg.length);
 
 			banner = sb.getBanner();
+			notifyBannerCallbacks(banner, sb.getLanguage());
+		}
+	}
+
+	private void notifyBannerCallbacks(String message, String language)
+	{
+		List<UserAuthBannerCallback> callbacks;
+
+		synchronized (bannerCallbacks)
+		{
+			callbacks = new ArrayList<UserAuthBannerCallback>(bannerCallbacks);
+		}
+
+		for (int i = 0; i < callbacks.size(); i++)
+		{
+			try
+			{
+				callbacks.get(i).receiveBanner(message, language);
+			}
+			catch (Exception ignore)
+			{
+				// Do not let application callback failures break authentication.
+			}
 		}
 	}
 

--- a/src/main/java/com/trilead/ssh2/packets/PacketUserauthBanner.java
+++ b/src/main/java/com/trilead/ssh2/packets/PacketUserauthBanner.java
@@ -26,6 +26,11 @@ public class PacketUserauthBanner
 		return message;
 	}
 
+	public String getLanguage()
+	{
+		return language;
+	}
+
 	public PacketUserauthBanner(byte payload[], int off, int len) throws IOException
 	{
 		this.payload = new byte[len];

--- a/src/main/java/com/trilead/ssh2/transport/TransportManager.java
+++ b/src/main/java/com/trilead/ssh2/transport/TransportManager.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Vector;
 
 import com.trilead.ssh2.ConnectionInfo;
@@ -15,12 +17,14 @@ import com.trilead.ssh2.DHGexParameters;
 import com.trilead.ssh2.IpVersion;
 import com.trilead.ssh2.ProxyData;
 import com.trilead.ssh2.ServerHostKeyVerifier;
+import com.trilead.ssh2.UserAuthBannerCallback;
 import com.trilead.ssh2.compression.ICompressor;
 import com.trilead.ssh2.crypto.CryptoWishList;
 import com.trilead.ssh2.crypto.cipher.BlockCipher;
 import com.trilead.ssh2.crypto.digest.MAC;
 import com.trilead.ssh2.log.Logger;
 import com.trilead.ssh2.packets.PacketDisconnect;
+import com.trilead.ssh2.packets.PacketUserauthBanner;
 import com.trilead.ssh2.packets.Packets;
 import com.trilead.ssh2.packets.TypesReader;
 
@@ -138,6 +142,8 @@ public class TransportManager implements ITransportConnection
 	Thread receiveThread;
 
 	Vector connectionMonitors = new Vector();
+	List<UserAuthBannerCallback> bannerCallbacks =
+			new ArrayList<UserAuthBannerCallback>();
 	boolean monitorsWereInformed = false;
 
 	private volatile ExtensionInfo extensionInfo = ExtensionInfo.noExtInfoSeen();
@@ -536,6 +542,36 @@ public class TransportManager implements ITransportConnection
 		}
 	}
 
+	public void setUserAuthBannerCallbacks(List<UserAuthBannerCallback> callbacks)
+	{
+		synchronized (this)
+		{
+			bannerCallbacks = new ArrayList<UserAuthBannerCallback>(callbacks);
+		}
+	}
+
+	private void notifyUserAuthBannerCallbacks(String message, String language)
+	{
+		List<UserAuthBannerCallback> callbacks;
+
+		synchronized (this)
+		{
+			callbacks = new ArrayList<UserAuthBannerCallback>(bannerCallbacks);
+		}
+
+		for (int i = 0; i < callbacks.size(); i++)
+		{
+			try
+			{
+				callbacks.get(i).receiveBanner(message, language);
+			}
+			catch (Exception ignore)
+			{
+				// Do not let application callback failures close the transport.
+			}
+		}
+	}
+
 	public void sendMessage(byte[] msg) throws IOException
 	{
 		if (Thread.currentThread() == receiveThread)
@@ -697,6 +733,13 @@ public class TransportManager implements ITransportConnection
 					mh = he.mh;
 					break;
 				}
+			}
+
+			if ((type == Packets.SSH_MSG_USERAUTH_BANNER) && (mh == null))
+			{
+				PacketUserauthBanner banner = new PacketUserauthBanner(msg, 0, msglen);
+				notifyUserAuthBannerCallbacks(banner.getBanner(), banner.getLanguage());
+				continue;
 			}
 
 			if (mh == null)

--- a/src/test/java/com/trilead/ssh2/auth/AuthenticationManagerBannerTest.java
+++ b/src/test/java/com/trilead/ssh2/auth/AuthenticationManagerBannerTest.java
@@ -1,0 +1,116 @@
+package com.trilead.ssh2.auth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+
+import com.trilead.ssh2.UserAuthBannerCallback;
+import com.trilead.ssh2.packets.PacketUserauthBanner;
+import com.trilead.ssh2.packets.Packets;
+import com.trilead.ssh2.packets.TypesWriter;
+import com.trilead.ssh2.transport.TransportManager;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthenticationManagerBannerTest
+{
+	@Mock
+	private TransportManager tm;
+
+	private AuthenticationManager authManager;
+	private List<UserAuthBannerCallback> bannerCallbacks;
+
+	@BeforeEach
+	public void setUp() throws IOException
+	{
+		bannerCallbacks = new ArrayList<UserAuthBannerCallback>();
+		authManager = new AuthenticationManager(tm, bannerCallbacks);
+
+		lenient().doAnswer(invocation -> null).when(tm).sendMessage(any(byte[].class));
+		lenient().doAnswer(invocation -> null).when(tm).registerMessageHandler(any(), any(int.class), any(int.class));
+		lenient().doAnswer(invocation -> null).when(tm).removeMessageHandler(any(), any(int.class), any(int.class));
+	}
+
+	@Test
+	public void authenticateNone_NotifiesBannerCallbackBeforeFailure() throws Exception
+	{
+		RecordingBannerCallback callback = new RecordingBannerCallback();
+		bannerCallbacks.add(callback);
+
+		queueMessages(
+				new byte[] { Packets.SSH_MSG_SERVICE_ACCEPT },
+				new PacketUserauthBanner("Visit https://login.tailscale.com/a/abc123", "en-US").getPayload(),
+				createUserauthFailure(new String[] { "publickey" }));
+
+		assertFalse(authManager.authenticateNone("testuser"));
+		assertEquals("Visit https://login.tailscale.com/a/abc123", callback.banner);
+		assertEquals("en-US", callback.language);
+		assertEquals(1, callback.calls);
+	}
+
+	@Test
+	public void authenticateNone_IgnoresBannerCallbackException() throws Exception
+	{
+		bannerCallbacks.add((banner, language) -> {
+			throw new IllegalStateException("callback failed");
+		});
+
+		queueMessages(
+				new byte[] { Packets.SSH_MSG_SERVICE_ACCEPT },
+				new PacketUserauthBanner("Login required", "").getPayload(),
+				createUserauthFailure(new String[] { "password" }));
+
+		assertFalse(authManager.authenticateNone("testuser"));
+	}
+
+	private void queueMessages(byte[]... messages)
+			throws IOException
+	{
+		for (byte[] message : messages)
+		{
+			authManager.handleMessage(message, message.length);
+		}
+	}
+
+	private byte[] createUserauthFailure(String[] methods)
+	{
+		TypesWriter tw = new TypesWriter();
+		StringBuilder methodList = new StringBuilder();
+
+		for (int i = 0; i < methods.length; i++)
+		{
+			if (i > 0)
+				methodList.append(",");
+			methodList.append(methods[i]);
+		}
+
+		tw.writeByte(Packets.SSH_MSG_USERAUTH_FAILURE);
+		tw.writeString(methodList.toString());
+		tw.writeBoolean(false);
+
+		return tw.getBytes();
+	}
+
+	private static class RecordingBannerCallback implements UserAuthBannerCallback
+	{
+		String banner;
+		String language;
+		int calls;
+
+		@Override
+		public void receiveBanner(String banner, String language)
+		{
+			this.banner = banner;
+			this.language = language;
+			calls++;
+		}
+	}
+}

--- a/src/test/java/com/trilead/ssh2/packets/PacketUserauthBannerTest.java
+++ b/src/test/java/com/trilead/ssh2/packets/PacketUserauthBannerTest.java
@@ -1,0 +1,19 @@
+package com.trilead.ssh2.packets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+public class PacketUserauthBannerTest
+{
+	@Test
+	public void parsesBannerLanguage() throws IOException
+	{
+		PacketUserauthBanner packet = new PacketUserauthBanner("Login required", "en-US");
+		PacketUserauthBanner parsed = new PacketUserauthBanner(packet.getPayload(), 0, packet.getPayload().length);
+
+		assertEquals("Login required", parsed.getBanner());
+		assertEquals("en-US", parsed.getLanguage());
+	}
+}


### PR DESCRIPTION
Tailscale uses a banner message during "none" authentication to provide a URL to click on. Add a way for clients to fetch it.