### PR TITLE
fix(strictKex): null check in isStrictKex

### DIFF
--- a/src/main/java/com/trilead/ssh2/transport/KexManager.java
+++ b/src/main/java/com/trilead/ssh2/transport/KexManager.java
@@ -897,7 +897,15 @@ public class KexManager
 		throw new IllegalStateException("Unkown KEX method! (" + kxs.np.kex_algo + ")");
 	}
 
+	/**
+	 * Returns whether strict key exchange has been negotiated for the current exchange.
+	 *
+	 * @return {@code true} if strict key exchange has been negotiated, or {@code false}
+	 *         if negotiation has not completed or strict key exchange is not enabled
+	 */
 	public boolean isStrictKex() {
-		return kxs.np.isStrictKex;
+		KexState currentKex = kxs;
+		NegotiatedParameters negotiatedParameters = currentKex == null ? null : currentKex.np;
+		return negotiatedParameters != null && negotiatedParameters.isStrictKex;
 	}
 }

--- a/src/test/java/com/trilead/ssh2/transport/KexManagerTest.java
+++ b/src/test/java/com/trilead/ssh2/transport/KexManagerTest.java
@@ -18,6 +18,7 @@ import org.testcontainers.shaded.com.trilead.ssh2.packets.Packets;
 import java.io.IOException;
 import java.security.SecureRandom;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -74,6 +75,13 @@ public class KexManagerTest {
 		kexManager.initiateKEX(new CryptoWishList(), new DHGexParameters());
 		kexManager.initiateKEX(new CryptoWishList(), new DHGexParameters());
 		verify(tm, times(1)).sendKexMessage(any());
+	}
+
+	@Test
+	public void strictKexBeforeNegotiation_ReturnsFalse() throws Exception {
+		kexManager.initiateKEX(new CryptoWishList(), new DHGexParameters());
+
+		assertFalse(kexManager.isStrictKex());
 	}
 
 	@Test


### PR DESCRIPTION
If one calls the isStrictKex before negotiation has completed, the negotiated parameters would be null and result in a NullPointerException. Change the semantics of the call slightly to mean "has strict KEX been negotiated."